### PR TITLE
Prettifier for datetimes

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -21,8 +21,8 @@ public class AddCommand extends Command {
 			+ "Parameters: \"EVENT_NAME\" from START_TIME to END_TIME on DATE" + "Example: " + COMMAND_WORD
 			+ "\"Be awesome\" from 1300 to 2359 on 07/10/2016";
 
-	public static final String MESSAGE_SUCCESS = "New task added: %1$s";
-	public static final String MESSAGE_SUCCESS_TIME_NULL = "START or END time not found but new task added!";
+	public static final String MESSAGE_SUCCESS = "New %1$s added: %2$s";
+	public static final String MESSAGE_SUCCESS_TIME_NULL = "START or END time not found but new %1$s added!";
 	public static final String MESSAGE_DUPLICATE_ITEM = "This task already exists in the to-do list";
 
 	private static final String DEFAULT_ITEM_NAME = "BLOCK";
@@ -65,10 +65,10 @@ public class AddCommand extends Command {
 		try {
 			model.addItem(toAdd);
 			// if user input something for time but it's not correct format
-			if (this.hasTimeString && (this.toAdd.getStartDate() == null || this.toAdd.getEndDate() == null)) {
-				return new CommandResult(MESSAGE_SUCCESS_TIME_NULL, toAdd);
+			if (this.hasTimeString && (this.toAdd.getStartDate() == null && this.toAdd.getEndDate() == null)) {
+				return new CommandResult(String.format(MESSAGE_SUCCESS_TIME_NULL, toAdd.getType()), toAdd);
 			} else {
-				return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd), toAdd);
+				return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd.getType(), toAdd), toAdd);
 			}
 		} catch (UniqueItemList.DuplicateItemException e) {
 			return new CommandResult(MESSAGE_DUPLICATE_ITEM);

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -49,7 +49,14 @@ public class AddCommand extends Command {
 		DateTimeParser parser = new DateTimeParser(timeStr);
 		LocalDateTime startTimeObj = parser.extractStartDate();
 		LocalDateTime endTimeObj = parser.extractEndDate();
-		this.toAdd = new Item(descriptionObj, startTimeObj, endTimeObj);
+		if(endTimeObj == null && startTimeObj != null) {
+		    // only one date token and it's parsed as startTime
+		    // use that as the end datetime instead and leave start
+		    // datetime as null
+		    this.toAdd = new Item(descriptionObj, null, startTimeObj);
+		} else {
+		    this.toAdd = new Item(descriptionObj, startTimeObj, endTimeObj);
+		}
 	}
 
 	@Override

--- a/src/main/java/seedu/address/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/address/logic/parser/DateTimeParser.java
@@ -2,8 +2,10 @@ package seedu.address.logic.parser;
 
 import java.time.DayOfWeek;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.Month;
+import java.time.Period;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
@@ -22,13 +24,13 @@ public class DateTimeParser {
     // the part of the command that contains the temporal part of the command
     private String datetime;
 
-	// natty parser object
+    // natty parser object
     // careful of name collision with our own Parser object
-	// static so we only need to initialize it once
-	private static PrettyTimeParser parser;
-	
-	// prettytime formatter
-	private static PrettyTime prettytime;
+    // static so we only need to initialize it once
+    private static PrettyTimeParser parser;
+
+    // prettytime formatter
+    private static PrettyTime prettytime;
 
     // result from parser
     private List<DateGroup> dategroups;
@@ -39,16 +41,16 @@ public class DateTimeParser {
         assert input.isEmpty() != true;
 
         this.datetime = input;
-		if (DateTimeParser.parser == null) {
-			DateTimeParser.parser = new PrettyTimeParser();
-		}
-		if (DateTimeParser.prettytime == null) {
-			DateTimeParser.prettytime = new PrettyTime();
-		}
+        if (DateTimeParser.parser == null) {
+            DateTimeParser.parser = new PrettyTimeParser();
+        }
+        if (DateTimeParser.prettytime == null) {
+            DateTimeParser.prettytime = new PrettyTime();
+        }
 
         // perform natty parsing
-		this.dategroups = DateTimeParser.parser.parseSyntax(input);
-		this.dates = DateTimeParser.parser.parse(input);
+        this.dategroups = DateTimeParser.parser.parseSyntax(input);
+        this.dates = DateTimeParser.parser.parse(input);
     }
 
     public LocalDateTime extractStartDate() {
@@ -60,18 +62,16 @@ public class DateTimeParser {
 
         return changeDateToLocalDateTime(this.dates.get(0));
     }
-    
+
     /**
      * Extracts a pretty relative start date
      * 
-     * Examples of pretty relative dates:
-     * (for future dates)
-     * "3 weeks from now", "2 days from now", "12 minutes from now",
-     * "moments from now"
+     * Examples of pretty relative dates: (for future dates) "3 weeks from now",
+     * "2 days from now", "12 minutes from now", "moments from now"
      * 
-     * (for past dates)
-     * "3 weeks ago", "2 days ago", "12 minutes ago",
-     * "moments ago"
+     * (for past dates) "3 weeks ago", "2 days ago", "12 minutes ago", "moments
+     * ago"
+     * 
      * @return
      * @author darren
      */
@@ -81,6 +81,7 @@ public class DateTimeParser {
 
     /**
      * Extracts a pretty start date
+     * 
      * @return
      * @author darren
      */
@@ -101,14 +102,12 @@ public class DateTimeParser {
     /**
      * Extracts a pretty relative end date
      * 
-     * Examples of pretty relative dates:
-     * (for future dates)
-     * "3 weeks from now", "2 days from now", "12 minutes from now",
-     * "moments from now"
+     * Examples of pretty relative dates: (for future dates) "3 weeks from now",
+     * "2 days from now", "12 minutes from now", "moments from now"
      * 
-     * (for past dates)
-     * "3 weeks ago", "2 days ago", "12 minutes ago",
-     * "moments ago"
+     * (for past dates) "3 weeks ago", "2 days ago", "12 minutes ago", "moments
+     * ago"
+     * 
      * @return
      * @author darren
      */
@@ -118,9 +117,10 @@ public class DateTimeParser {
         }
         return extractPrettyRelativeDate(1);
     }
-    
+
     /**
      * Extracts a pretty end date
+     * 
      * @return
      * @author darren
      */
@@ -149,111 +149,116 @@ public class DateTimeParser {
      * @author darren
      */
     public static LocalDateTime changeDateToLocalDateTime(Date date) {
-        Instant instant = date.toInstant().truncatedTo(ChronoUnit.SECONDS); // strip milliseconds
-        return LocalDateTime.ofInstant(instant,
-                ZoneId.systemDefault());
+        Instant instant = date.toInstant().truncatedTo(ChronoUnit.SECONDS); // strip
+                                                                            // milliseconds
+        return LocalDateTime.ofInstant(instant, ZoneId.systemDefault());
     }
 
     /**
-     * Helper method for determining a human-readable relative date
-     * from the date tokens in the input string
+     * Helper method for determining a human-readable relative date from the
+     * date tokens in the input string
      * 
-     * Note that this is dependent on the local system time, e.g.
-     * the output from java.util.Date()
+     * Note that this is dependent on the local system time, e.g. the output
+     * from java.util.Date()
      * 
-     * Examples of pretty relative dates:
-     * (for future dates)
-     * "3 weeks from now", "2 days from now", "12 minutes from now",
-     * "moments from now"
+     * Examples of pretty relative dates: (for future dates) "3 weeks from now",
+     * "2 days from now", "12 minutes from now", "moments from now"
      * 
-     * (for past dates)
-     * "3 weeks ago", "2 days ago", "12 minutes ago",
-     * "moments ago"
+     * (for past dates) "3 weeks ago", "2 days ago", "12 minutes ago", "moments
+     * ago"
      * 
      * @param index
-     *      index of target java.util.Date inside DateTimeParser's List<Date>
-     * @return
-     *      pretty relative date
+     *            index of target java.util.Date inside DateTimeParser's
+     *            List<Date>
+     * @return pretty relative date
      * @author darren
      */
     private String extractPrettyRelativeDate(int index) {
         assert this.dates != null;
         return prettytime.format(this.dates.get(index));
     }
-    
+
     /**
-     * Helper method for determining a human-readable pretty date
-     * from date tokens in the input string
+     * Helper method for determining a human-readable pretty date from date
+     * tokens in the input string
      * 
-     * This is independent of local system time, although it is
-     * intended for dates that are upcoming in the next 7 days as
-     * only the day of the week is indicated instead of a date.
+     * This is independent of local system time, although it is intended for
+     * dates that are upcoming in the next 7 days as only the day of the week is
+     * indicated instead of a date.
      * 
-     * This method does NOT check if the input date is within the
-     * next 7 days.
+     * This method does NOT check if the input date is within the next 7 days.
      * 
-     * Examples:
-     * "Monday, 6:30AM"
-     * "Saturday, 12:37PM"
+     * Examples: "Monday, 6:30AM" "Saturday, 12:37PM"
      * 
      * @param index
-     * @return
-     *      pretty date for this week
+     * @return pretty date for this week
      */
     private String extractPrettyDate(int index) {
         assert this.dates != null;
-        
+
         LocalDateTime ldt = changeDateToLocalDateTime(this.dates.get(index));
-        
+
         DayOfWeek day = ldt.getDayOfWeek();
         int hour = ldt.getHour();
         int minute = ldt.getMinute();
-        
+
         // convert to 12h time from 24h
-        if(hour > 12) {
-            hour = hour%12;
+        if (hour > 12) {
+            hour = hour % 12;
         }
-        
-        return toTitleCase(day.toString()) + ", " + hour + ":" + String.format("%02d", minute) + computeMeridian(hour);
+
+        return toTitleCase(day.toString()) + ", " + hour + ":"
+                + String.format("%02d", minute) + computeMeridian(hour);
     }
-    
+
+    /**
+     * Computes number of days between current system time to the given
+     * java.time.LocalDateTime
+     * 
+     * @param ldt
+     *            future LocalDateTime
+     * @return number of days between now to future LocalDateTime
+     * @author darren
+     */
+    public static int computeDaysTo(LocalDateTime ldt) {
+        assert ldt.isAfter(LocalDateTime.now());
+        return Period.between(LocalDate.now(), ldt.toLocalDate()).getDays();
+    }
+
     /**
      * Returns the meridian of a given hour
      * 
-     * Examples:
-     * Returns "PM" if given hour is 23 (11PM)
-     * Returns "AM" if given hour is 11 (11AM)
+     * Examples: Returns "PM" if given hour is 23 (11PM) Returns "AM" if given
+     * hour is 11 (11AM)
      * 
      * @param hour
-     *      integer hour in 24h format
-     * @return
-     *      meridian of the hour
+     *            integer hour in 24h format
+     * @return meridian of the hour
      * @author darren
      */
     private static String computeMeridian(int hour) {
-        if(hour > 12) {
+        if (hour > 12) {
             return "PM";
         }
         return "AM";
     }
-    
+
     /**
      * Transforms a String into a title-cased string.
      * 
-     * The first letter of the string will be uppercase
-     * while every letter after will be lowercase.
+     * The first letter of the string will be uppercase while every letter after
+     * will be lowercase.
      * 
      * @param string
-     *      string to be transformed
-     * @return
-     *      s in title case
+     *            string to be transformed
+     * @return s in title case
      * @author darren
      */
     private static String toTitleCase(String string) {
-        return string.substring(0, 1).toUpperCase() +
-                   string.substring(1).toLowerCase();
+        return string.substring(0, 1).toUpperCase()
+                + string.substring(1).toLowerCase();
     }
-    
+
     public DateGroup getDateGroup(int index) {
         return this.dategroups.get(index);
     }

--- a/src/main/java/seedu/address/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/address/logic/parser/DateTimeParser.java
@@ -7,6 +7,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.List;
 
+import org.ocpsoft.prettytime.PrettyTime;
 import org.ocpsoft.prettytime.nlp.PrettyTimeParser;
 import org.ocpsoft.prettytime.nlp.parse.DateGroup;
 
@@ -23,6 +24,9 @@ public class DateTimeParser {
     // careful of name collision with our own Parser object
 	// static so we only need to initialize it once
 	private static PrettyTimeParser parser;
+	
+	// prettytime formatter
+	private static PrettyTime prettytime;
 
     // result from parser
     private List<DateGroup> dategroups;

--- a/src/main/java/seedu/address/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/address/logic/parser/DateTimeParser.java
@@ -40,6 +40,9 @@ public class DateTimeParser {
 		if (DateTimeParser.parser == null) {
 			DateTimeParser.parser = new PrettyTimeParser();
 		}
+		if (DateTimeParser.prettytime == null) {
+			DateTimeParser.prettytime = new PrettyTime();
+		}
 
         // perform natty parsing
 		this.dategroups = DateTimeParser.parser.parseSyntax(input);
@@ -55,6 +58,10 @@ public class DateTimeParser {
 
         return changeDateToLocalDateTime(this.dates.get(0));
     }
+    
+    public String extractPrettyRelativeStartDate() {
+        return extractPrettyRelativeDate(0);
+    }
 
     public LocalDateTime extractEndDate() {
         assert this.dates != null;
@@ -64,6 +71,13 @@ public class DateTimeParser {
         }
 
         return changeDateToLocalDateTime(this.dates.get(1));
+    }
+
+    public String extractPrettyRelativeEndDate() {
+        if (this.dates.size() < 2) {
+            return extractPrettyRelativeStartDate();
+        }
+        return extractPrettyRelativeDate(1);
     }
 
     public boolean isRecurring() {
@@ -87,6 +101,31 @@ public class DateTimeParser {
         Instant instant = date.toInstant().truncatedTo(ChronoUnit.SECONDS); // strip milliseconds
         return LocalDateTime.ofInstant(instant,
                 ZoneId.systemDefault());
+    }
+
+    /**
+     * Helper method for determining a human-readable relative date
+     * from the date tokens in the input string
+     * 
+     * Note that this is dependent on the local system time, e.g.
+     * the output from java.util.Date()
+     * 
+     * Examples of pretty relative dates:
+     * (for future dates)
+     * "3 weeks from now", "2 days from now", "12 minutes from now",
+     * "moments from now"
+     * 
+     * (for past dates)
+     * "3 weeks ago", "2 days ago", "12 minutes ago",
+     * "moments ago"
+     * 
+     * @param index
+     * @return
+     * @author darren
+     */
+    private String extractPrettyRelativeDate(int index) {
+        assert this.dates != null;
+        return prettytime.format(this.dates.get(index));
     }
 
     public DateGroup getDateGroup(int index) {

--- a/src/main/java/seedu/address/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/address/logic/parser/DateTimeParser.java
@@ -218,17 +218,20 @@ public class DateTimeParser {
 
         // add relative prefix (this/next <day of week>) if applicable
         if(computeDaysTo(ldt) < 14) {
+            // is within the next two weeks
             return makeRelativePrefix(ldt) + dayOfWeek + ", " + extractTwelveHourTime(ldt);
         }
 
         // explicit date; no relative prefix
-        String prettyDateTime;
+        String prettyDate;
         if(computeDaysTo(ldt) < 365) {
-            prettyDateTime = ldt.toLocalDate().format(ABRIDGED_DATE_FORMAT);
+            // same year
+            prettyDate = ldt.toLocalDate().format(ABRIDGED_DATE_FORMAT);
         } else {
-            prettyDateTime = ldt.toLocalDate().format(EXPLICIT_DATE_FORMAT);
+            // different years
+            prettyDate = ldt.toLocalDate().format(EXPLICIT_DATE_FORMAT);
         }
-        return dayOfWeekShort + " " + prettyDateTime + ", " + extractTwelveHourTime(ldt);
+        return dayOfWeekShort + " " + prettyDate + ", " + extractTwelveHourTime(ldt);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/address/logic/parser/DateTimeParser.java
@@ -120,7 +120,9 @@ public class DateTimeParser {
      * "moments ago"
      * 
      * @param index
+     *      index of target java.util.Date inside DateTimeParser's List<Date>
      * @return
+     *      pretty relative date
      * @author darren
      */
     private String extractPrettyRelativeDate(int index) {

--- a/src/main/java/seedu/address/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/address/logic/parser/DateTimeParser.java
@@ -43,9 +43,9 @@ public class DateTimeParser {
     public static final DateTimeFormatter ABRIDGED_DATE_FORMAT = DateTimeFormatter.ofPattern("dd MMM");
     public static final DateTimeFormatter EXPLICIT_DATE_FORMAT = DateTimeFormatter.ofPattern("dd MMM yyyy");
     public static final DateTimeFormatter TWELVE_HOUR_TIME = DateTimeFormatter.ofPattern("h:mma");
-    public static final DateTimeFormatter FULL_DAYOFWEEK = DateTimeFormatter.ofPattern("EEEE");
+    public static final DateTimeFormatter LONG_DAYOFWEEK = DateTimeFormatter.ofPattern("EEEE");
     public static final DateTimeFormatter SHORT_DAYOFWEEK = DateTimeFormatter.ofPattern("EEE");
-
+    
     public DateTimeParser(String input) {
         assert input != null;
         assert input.isEmpty() != true;
@@ -219,7 +219,7 @@ public class DateTimeParser {
         // add relative prefix (this/next <day of week>) if applicable
         if(computeDaysTo(ldt) < 14) {
             // is within the next two weeks
-            return makeRelativePrefix(ldt) + extractDayOfWeek(ldt, true) + ", " + extractTwelveHourTime(ldt);
+            return makeRelativePrefix(ldt) + extractLongDayOfWeek(ldt) + ", " + extractTwelveHourTime(ldt);
         }
 
         // explicit date; no relative prefix
@@ -231,7 +231,7 @@ public class DateTimeParser {
             // different years
             prettyDate = ldt.toLocalDate().format(EXPLICIT_DATE_FORMAT);
         }
-        return extractDayOfWeek(ldt, false) + " " + prettyDate + ", " + extractTwelveHourTime(ldt);
+        return extractShortDayOfWeek(ldt) + " " + prettyDate + ", " + extractTwelveHourTime(ldt);
     }
 
     /**
@@ -245,7 +245,7 @@ public class DateTimeParser {
     public static String extractTwelveHourTime(LocalDateTime ldt) {
         return ldt.toLocalTime().format(TWELVE_HOUR_TIME);
     }
-    
+
     /**
      * Extracts the day-of-week component of a java.time.LocalDateTime object
      * and returns it in long or short format (Monday or Mon)
@@ -257,11 +257,19 @@ public class DateTimeParser {
      *      day-of-week
      * @author darren
      */
-    public static String extractDayOfWeek(LocalDateTime ldt, boolean isLongFormat) {
+    private static String extractDayOfWeek(LocalDateTime ldt, boolean isLongFormat) {
         if(isLongFormat) {
-            return ldt.toLocalDate().format(FULL_DAYOFWEEK);
+            return ldt.toLocalDate().format(LONG_DAYOFWEEK);
         }
         return ldt.toLocalDate().format(SHORT_DAYOFWEEK);
+    }
+
+    public static String extractLongDayOfWeek(LocalDateTime ldt) {
+        return extractDayOfWeek(ldt, true);
+    }
+
+    public static String extractShortDayOfWeek(LocalDateTime ldt) {
+        return extractDayOfWeek(ldt, false);
     }
     
     /**

--- a/src/main/java/seedu/address/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/address/logic/parser/DateTimeParser.java
@@ -236,7 +236,7 @@ public class DateTimeParser {
      * @return meridian of the hour
      * @author darren
      */
-    private static String computeMeridian(int hour) {
+    public static String computeMeridian(int hour) {
         if (hour > 12) {
             return "PM";
         }
@@ -254,7 +254,7 @@ public class DateTimeParser {
      * @return s in title case
      * @author darren
      */
-    private static String toTitleCase(String string) {
+    public static String toTitleCase(String string) {
         return string.substring(0, 1).toUpperCase()
                 + string.substring(1).toLowerCase();
     }

--- a/src/main/java/seedu/address/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/address/logic/parser/DateTimeParser.java
@@ -79,6 +79,15 @@ public class DateTimeParser {
         return extractPrettyRelativeDate(0);
     }
 
+    /**
+     * Extracts a pretty start date
+     * @return
+     * @author darren
+     */
+    public String extractPrettyStartDate() {
+        return extractPrettyDate(0);
+    }
+
     public LocalDateTime extractEndDate() {
         assert this.dates != null;
 
@@ -90,7 +99,7 @@ public class DateTimeParser {
     }
 
     /**
-     * Extracts a pretty relative start date
+     * Extracts a pretty relative end date
      * 
      * Examples of pretty relative dates:
      * (for future dates)
@@ -108,6 +117,18 @@ public class DateTimeParser {
             return extractPrettyRelativeStartDate();
         }
         return extractPrettyRelativeDate(1);
+    }
+    
+    /**
+     * Extracts a pretty end date
+     * @return
+     * @author darren
+     */
+    public String extractPrettyEndDate() {
+        if (this.dates.size() < 2) {
+            return extractPrettyStartDate();
+        }
+        return extractPrettyDate(1);
     }
 
     public boolean isRecurring() {
@@ -179,7 +200,7 @@ public class DateTimeParser {
      * @return
      *      pretty date for this week
      */
-    private String extractThisWeekPrettyDate(int index) {
+    private String extractPrettyDate(int index) {
         assert this.dates != null;
         
         LocalDateTime ldt = changeDateToLocalDateTime(this.dates.get(index));

--- a/src/main/java/seedu/address/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/address/logic/parser/DateTimeParser.java
@@ -7,6 +7,7 @@ import java.time.LocalDateTime;
 import java.time.Month;
 import java.time.Period;
 import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.List;
@@ -37,6 +38,9 @@ public class DateTimeParser {
     private List<Date> dates;
     
     public static final String EMPTY_STRING = "";
+
+    public static final DateTimeFormatter ABRIDGED_DATE_FORMAT = DateTimeFormatter.ofPattern("dd LLLL");
+    public static final DateTimeFormatter EXPLICIT_DATE_FORMAT = DateTimeFormatter.ofPattern("dd LLLL yyyy");
 
     public DateTimeParser(String input) {
         assert input != null;

--- a/src/main/java/seedu/address/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/address/logic/parser/DateTimeParser.java
@@ -37,16 +37,23 @@ public class DateTimeParser {
     // result from parser
     private List<DateGroup> dategroups;
     private List<Date> dates;
-    
+
     public static final String EMPTY_STRING = "";
+    public static final String TODAY_DATE_REF = "Today";
+    public static final String TOMORROW_DATE_REF = "Tomorrow";
 
     // DateTime formatting patterns
-    public static final DateTimeFormatter ABRIDGED_DATE_FORMAT = DateTimeFormatter.ofPattern("dd MMM");
-    public static final DateTimeFormatter EXPLICIT_DATE_FORMAT = DateTimeFormatter.ofPattern("dd MMM yyyy");
-    public static final DateTimeFormatter TWELVE_HOUR_TIME = DateTimeFormatter.ofPattern("h:mma");
-    public static final DateTimeFormatter LONG_DAYOFWEEK = DateTimeFormatter.ofPattern("EEEE");
-    public static final DateTimeFormatter SHORT_DAYOFWEEK = DateTimeFormatter.ofPattern("EEE");
-    
+    public static final DateTimeFormatter ABRIDGED_DATE_FORMAT = DateTimeFormatter
+            .ofPattern("dd MMM");
+    public static final DateTimeFormatter EXPLICIT_DATE_FORMAT = DateTimeFormatter
+            .ofPattern("dd MMM yyyy");
+    public static final DateTimeFormatter TWELVE_HOUR_TIME = DateTimeFormatter
+            .ofPattern("h:mma");
+    public static final DateTimeFormatter LONG_DAYOFWEEK = DateTimeFormatter
+            .ofPattern("EEEE");
+    public static final DateTimeFormatter SHORT_DAYOFWEEK = DateTimeFormatter
+            .ofPattern("EEE");
+
     public DateTimeParser(String input) {
         assert input != null;
         assert input.isEmpty() != true;
@@ -86,41 +93,43 @@ public class DateTimeParser {
         return changeDateToLocalDateTime(
                 this.dategroups.get(0).getRecursUntil());
     }
-    
+
     /**
      * Makes the pretty datetime line for an Item's card on the UI.
      * 
-     * The UI should only be calling this method for displaying datetime
-     * of event on the Item's card on the agenda pane.
+     * The UI should only be calling this method for displaying datetime of
+     * event on the Item's card on the agenda pane.
      * 
      * @return
      * @author darren
      */
-    public static String extractPrettyItemCardDateTime(LocalDateTime start, LocalDateTime end) {
-        if(start == null && end == null) {
+    public static String extractPrettyItemCardDateTime(LocalDateTime start,
+            LocalDateTime end) {
+        if (start == null && end == null) {
             return EMPTY_STRING;
         }
-        
-        if(start == null) {
+
+        if (start == null) {
             return extractPrettyDateTime(end);
         }
-        
-        if(end == null) {
+
+        if (end == null) {
             return extractPrettyDateTime(start);
         }
-        
+
         // is an event with a definite start and end datetime
-        if(isSameDay(start, end)) {
-            return extractPrettyDateTime(start) + " - " + extractTwelveHourTime(end);
+        if (isSameDay(start, end)) {
+            return extractPrettyDateTime(start) + " - "
+                    + extractTwelveHourTime(end);
         }
-        
+
         // not same day
-        return extractPrettyDateTime(start) + " - " + extractPrettyDateTime(end);
+        return extractPrettyDateTime(start) + " - "
+                + extractPrettyDateTime(end);
     }
-    
+
     /**
-     * Checks if two given java.time.LocalDateTime objects are
-     * of the same day.
+     * Checks if two given java.time.LocalDateTime objects are of the same day.
      * 
      * @param ldt1
      * @param ldt2
@@ -130,10 +139,11 @@ public class DateTimeParser {
     public static boolean isSameDay(LocalDateTime ldt1, LocalDateTime ldt2) {
         return ldt1.toLocalDate().equals(ldt2.toLocalDate());
     }
-    
+
     /**
-     * Check if the given java.time.LocalDateTime object is the same
-     * date as the current date on local system time
+     * Check if the given java.time.LocalDateTime object is the same date as the
+     * current date on local system time
+     * 
      * @param ldt
      * @return true if the LocalDateTime is for today, false otherwise
      * @author darren
@@ -141,10 +151,11 @@ public class DateTimeParser {
     public static boolean isToday(LocalDateTime ldt) {
         return isSameDay(ldt, LocalDateTime.now());
     }
-    
+
     /**
-     * Check if the given java.time.LocalDateTime object is the same
-     * date as the next day relative to the local system time
+     * Check if the given java.time.LocalDateTime object is the same date as the
+     * next day relative to the local system time
+     * 
      * @param ldt
      * @return true if the LocalDateTime is for tomorrow, false otherwise
      * @author darren
@@ -165,7 +176,7 @@ public class DateTimeParser {
                                                                             // milliseconds
         return LocalDateTime.ofInstant(instant, ZoneId.systemDefault());
     }
-    
+
     /**
      * Helper method for casting java.time.LocalDateTime to java.util.Date
      * 
@@ -198,7 +209,7 @@ public class DateTimeParser {
      * @author darren
      */
     public static String extractPrettyRelativeDateTime(LocalDateTime ldt) {
-        if(ldt == null) {
+        if (ldt == null) {
             return EMPTY_STRING;
         }
         return prettytime.format(changeLocalDateTimeToDate(ldt));
@@ -208,34 +219,45 @@ public class DateTimeParser {
      * Helper method for determining a human-readable pretty date from date
      * tokens in the input string
      * 
-     * Examples: "This Monday, 6:30AM", "Next Saturday, 12:37PM",
-     * "Mon 27 November, 9:30PM"
+     * Examples: "This Monday, 6:30AM", "Next Saturday, 12:37PM", "Mon 27
+     * November, 9:30PM", "Today, 3:57PM"
      * 
      * @param index
      * @return pretty date for this week
      */
     public static String extractPrettyDateTime(LocalDateTime ldt) {
+        // special case for today/tomorrow relative to local system time
+        if (isToday(ldt)) {
+            return TODAY_DATE_REF + ", " + extractTwelveHourTime(ldt);
+        }
+
+        if (isTomorrow(ldt)) {
+            return TOMORROW_DATE_REF + ", " + extractTwelveHourTime(ldt);
+        }
+
         // add relative prefix (this/next <day of week>) if applicable
-        if(computeDaysTo(ldt) < 14) {
+        if (computeDaysTo(ldt) < 14) {
             // is within the next two weeks
-            return makeRelativePrefix(ldt) + extractLongDayOfWeek(ldt) + ", " + extractTwelveHourTime(ldt);
+            return makeRelativePrefix(ldt) + extractLongDayOfWeek(ldt) + ", "
+                    + extractTwelveHourTime(ldt);
         }
 
         // explicit date; no relative prefix
         String prettyDate;
-        if(computeDaysTo(ldt) < 365) {
-            // same year
+        if (computeDaysTo(ldt) < 365) {
+            // same year in start and end datetimes
             prettyDate = ldt.toLocalDate().format(ABRIDGED_DATE_FORMAT);
         } else {
-            // different years
+            // different years in start and end datetimes
             prettyDate = ldt.toLocalDate().format(EXPLICIT_DATE_FORMAT);
         }
-        return extractShortDayOfWeek(ldt) + " " + prettyDate + ", " + extractTwelveHourTime(ldt);
+        return extractShortDayOfWeek(ldt) + " " + prettyDate + ", "
+                + extractTwelveHourTime(ldt);
     }
 
     /**
-     * Extracts the time component of a java.time.LocalDateTime object
-     * and returns it in 12-hour format.
+     * Extracts the time component of a java.time.LocalDateTime object and
+     * returns it in 12-hour format.
      * 
      * @param ldt
      * @return
@@ -251,13 +273,13 @@ public class DateTimeParser {
      * 
      * @param ldt
      * @param isLongFormat
-     *      result is long format?
-     * @return
-     *      day-of-week
+     *            result is long format?
+     * @return day-of-week
      * @author darren
      */
-    private static String extractDayOfWeek(LocalDateTime ldt, boolean isLongFormat) {
-        if(isLongFormat) {
+    private static String extractDayOfWeek(LocalDateTime ldt,
+            boolean isLongFormat) {
+        if (isLongFormat) {
             return ldt.toLocalDate().format(LONG_DAYOFWEEK);
         }
         return ldt.toLocalDate().format(SHORT_DAYOFWEEK);
@@ -270,9 +292,10 @@ public class DateTimeParser {
     public static String extractShortDayOfWeek(LocalDateTime ldt) {
         return extractDayOfWeek(ldt, false);
     }
-    
+
     /**
-     * Determine the appropriate relative prefix to use for reference to a DayOfWeek enum
+     * Determine the appropriate relative prefix to use for reference to a
+     * DayOfWeek enum
      * 
      * @param ldt
      * @return
@@ -286,7 +309,7 @@ public class DateTimeParser {
         }
         return EMPTY_STRING;
     }
-    
+
     /**
      * Computes number of days between current system time to the given
      * java.time.LocalDateTime

--- a/src/main/java/seedu/address/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/address/logic/parser/DateTimeParser.java
@@ -141,6 +141,17 @@ public class DateTimeParser {
     public static boolean isToday(LocalDateTime ldt) {
         return isSameDay(ldt, LocalDateTime.now());
     }
+    
+    /**
+     * Check if the given java.time.LocalDateTime object is the same
+     * date as the next day relative to the local system time
+     * @param ldt
+     * @return true if the LocalDateTime is for tomorrow, false otherwise
+     * @author darren
+     */
+    public static boolean isTomorrow(LocalDateTime ldt) {
+        return isSameDay(ldt, LocalDateTime.now().plusDays(1L));
+    }
 
     /**
      * Helper method for casting java.util.Date to java.time.LocalDateTime

--- a/src/main/java/seedu/address/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/address/logic/parser/DateTimeParser.java
@@ -81,8 +81,8 @@ public class DateTimeParser {
      * @return
      * @author darren
      */
-    public String extractPrettyRelativeStartDate() {
-        return extractPrettyRelativeDate(0);
+    public String extractPrettyRelativeStartDateTime() {
+        return extractPrettyRelativeDateTime(0);
     }
 
     /**
@@ -91,8 +91,8 @@ public class DateTimeParser {
      * @return
      * @author darren
      */
-    public String extractPrettyStartDate() {
-        return extractPrettyDate(0);
+    public String extractPrettyStartDateTime() {
+        return extractPrettyDateTime(0);
     }
 
     public LocalDateTime extractEndDate() {
@@ -117,11 +117,11 @@ public class DateTimeParser {
      * @return
      * @author darren
      */
-    public String extractPrettyRelativeEndDate() {
+    public String extractPrettyRelativeEndDateTime() {
         if (this.dates.size() < 2) {
-            return extractPrettyRelativeStartDate();
+            return extractPrettyRelativeStartDateTime();
         }
-        return extractPrettyRelativeDate(1);
+        return extractPrettyRelativeDateTime(1);
     }
 
     /**
@@ -130,11 +130,11 @@ public class DateTimeParser {
      * @return
      * @author darren
      */
-    public String extractPrettyEndDate() {
+    public String extractPrettyEndDateTime() {
         if (this.dates.size() < 2) {
-            return extractPrettyStartDate();
+            return extractPrettyStartDateTime();
         }
-        return extractPrettyDate(1);
+        return extractPrettyDateTime(1);
     }
 
     public boolean isRecurring() {
@@ -145,7 +145,6 @@ public class DateTimeParser {
         return changeDateToLocalDateTime(
                 this.dategroups.get(0).getRecursUntil());
     }
-    
     
     /**
      * Checks if two given java.time.LocalDateTime objects are
@@ -193,7 +192,7 @@ public class DateTimeParser {
      * @return pretty relative date
      * @author darren
      */
-    private String extractPrettyRelativeDate(int index) {
+    private String extractPrettyRelativeDateTime(int index) {
         assert this.dates != null;
         return prettytime.format(this.dates.get(index));
     }
@@ -208,7 +207,7 @@ public class DateTimeParser {
      * @param index
      * @return pretty date for this week
      */
-    private String extractPrettyDate(int index) {
+    private String extractPrettyDateTime(int index) {
         assert this.dates != null;
 
         LocalDateTime ldt = changeDateToLocalDateTime(this.dates.get(index));

--- a/src/main/java/seedu/address/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/address/logic/parser/DateTimeParser.java
@@ -39,8 +39,8 @@ public class DateTimeParser {
     
     public static final String EMPTY_STRING = "";
 
-    public static final DateTimeFormatter ABRIDGED_DATE_FORMAT = DateTimeFormatter.ofPattern("dd LLLL");
-    public static final DateTimeFormatter EXPLICIT_DATE_FORMAT = DateTimeFormatter.ofPattern("dd LLLL yyyy");
+    public static final DateTimeFormatter ABRIDGED_DATE_FORMAT = DateTimeFormatter.ofPattern("dd MMM");
+    public static final DateTimeFormatter EXPLICIT_DATE_FORMAT = DateTimeFormatter.ofPattern("dd MMM yyyy");
 
     public DateTimeParser(String input) {
         assert input != null;
@@ -206,6 +206,7 @@ public class DateTimeParser {
         }
         
         String dayOfWeek = toTitleCase(ldt.getDayOfWeek().toString());
+        String dayOfWeekShort = dayOfWeek.substring(0, 3);
         String minute = String.format("%02d", ldt.getMinute());
 
         // add relative prefix (this/next <day of week>) if applicable
@@ -215,7 +216,13 @@ public class DateTimeParser {
         }
 
         // explicit date; no relative prefix
-        return ldt.toLocalDate().toString() + ", " + hour + ":"
+        String prettyDateTime;
+        if(computeDaysTo(ldt) < 365) {
+            prettyDateTime = ldt.toLocalDate().format(ABRIDGED_DATE_FORMAT);
+        } else {
+            prettyDateTime = ldt.toLocalDate().format(EXPLICIT_DATE_FORMAT);
+        }
+        return dayOfWeekShort + " " + prettyDateTime + ", " + hour + ":"
                 + minute + meridian;
     }
 
@@ -244,9 +251,9 @@ public class DateTimeParser {
      * @return number of days between now to future LocalDateTime
      * @author darren
      */
-    public static int computeDaysTo(LocalDateTime ldt) {
+    public static long computeDaysTo(LocalDateTime ldt) {
         assert ldt.isAfter(LocalDateTime.now());
-        return Period.between(LocalDate.now(), ldt.toLocalDate()).getDays();
+        return ChronoUnit.DAYS.between(LocalDate.now(), ldt.toLocalDate());
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/address/logic/parser/DateTimeParser.java
@@ -1,13 +1,9 @@
 package seedu.address.logic.parser;
 
-import java.time.DayOfWeek;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.Month;
-import java.time.Period;
 import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;

--- a/src/main/java/seedu/address/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/address/logic/parser/DateTimeParser.java
@@ -145,6 +145,20 @@ public class DateTimeParser {
         return changeDateToLocalDateTime(
                 this.dategroups.get(0).getRecursUntil());
     }
+    
+    
+    /**
+     * Checks if two given java.time.LocalDateTime objects are
+     * of the same day.
+     * 
+     * @param ldt1
+     * @param ldt2
+     * @return true if they are both the same day, false otherwise
+     * @author darren
+     */
+    public static boolean isSameDay(LocalDateTime ldt1, LocalDateTime ldt2) {
+        return ldt1.toLocalDate().equals(ldt2.toLocalDate());
+    }
 
     /**
      * helper method for casting java.util.Date to java.time.LocalDateTime
@@ -188,7 +202,8 @@ public class DateTimeParser {
      * Helper method for determining a human-readable pretty date from date
      * tokens in the input string
      * 
-     * Examples: "This Monday, 6:30AM", "Next Saturday, 12:37PM"
+     * Examples: "This Monday, 6:30AM", "Next Saturday, 12:37PM",
+     * "Mon 27 November, 9:30PM"
      * 
      * @param index
      * @return pretty date for this week

--- a/src/main/java/seedu/address/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/address/logic/parser/DateTimeParser.java
@@ -182,7 +182,7 @@ public class DateTimeParser {
      * @author darren
      */
     public static String extractPrettyRelativeDateTime(LocalDateTime ldt) {
-        return null;
+        return prettytime.format(changeLocalDateTimeToDate(ldt));
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/address/logic/parser/DateTimeParser.java
@@ -29,10 +29,10 @@ public class DateTimeParser {
     // natty parser object
     // careful of name collision with our own Parser object
     // static so we only need to initialize it once
-    private static PrettyTimeParser parser;
+    private static PrettyTimeParser parser = new PrettyTimeParser();
 
     // prettytime formatter
-    private static PrettyTime prettytime;
+    private static PrettyTime prettytime = new PrettyTime();
 
     // result from parser
     private List<DateGroup> dategroups;
@@ -52,12 +52,6 @@ public class DateTimeParser {
         assert input.isEmpty() != true;
 
         this.datetime = input;
-        if (DateTimeParser.parser == null) {
-            DateTimeParser.parser = new PrettyTimeParser();
-        }
-        if (DateTimeParser.prettytime == null) {
-            DateTimeParser.prettytime = new PrettyTime();
-        }
 
         // perform natty parsing
         this.dategroups = DateTimeParser.parser.parseSyntax(input);
@@ -135,6 +129,17 @@ public class DateTimeParser {
      */
     public static boolean isSameDay(LocalDateTime ldt1, LocalDateTime ldt2) {
         return ldt1.toLocalDate().equals(ldt2.toLocalDate());
+    }
+    
+    /**
+     * Check if the given java.time.LocalDateTime object is the same
+     * date as the current date on local system time
+     * @param ldt
+     * @return true if the LocalDateTime is for today, false otherwise
+     * @author darren
+     */
+    public static boolean isToday(LocalDateTime ldt) {
+        return isSameDay(ldt, LocalDateTime.now());
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/address/logic/parser/DateTimeParser.java
@@ -151,6 +151,33 @@ public class DateTimeParser {
     }
     
     /**
+     * Makes the pretty datetime line for an Item's card on the UI.
+     * 
+     * The UI should only be calling this method for displaying datetime
+     * of event on the Item's card on the agenda pane.
+     * 
+     * @return
+     * @author darren
+     */
+    public String extractPrettyItemCardDateTime() {
+        assert this.dates != null;
+        
+        if(this.dates.size() < 2) {
+            return extractPrettyStartDateTime();
+        }
+        
+        // is an event with a definite start and end datetime
+        LocalDateTime start = changeDateToLocalDateTime(this.dates.get(0));
+        LocalDateTime end = changeDateToLocalDateTime(this.dates.get(1));
+        if(isSameDay(start, end)) {
+            return extractPrettyStartDateTime() + " - " + extractTwelveHourTime(end);
+        }
+        
+        // not same day
+        return extractPrettyDateTime(0) + " - " + extractPrettyDateTime(1);
+    }
+    
+    /**
      * Checks if two given java.time.LocalDateTime objects are
      * of the same day.
      * 

--- a/src/main/java/seedu/address/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/address/logic/parser/DateTimeParser.java
@@ -39,14 +39,15 @@ public class DateTimeParser {
 
     public static final String EMPTY_STRING = "";
     public static final String SINGLE_WHITESPACE = " ";
-    
+
     // handy strings for making pretty dates
     public static final String TODAY_DATE_REF = "Today";
     public static final String TOMORROW_DATE_REF = "Tomorrow";
     public static final String NEXT_WEEK_REF = "Next" + SINGLE_WHITESPACE;
     public static final String THIS_WEEK_REF = "This" + SINGLE_WHITESPACE;
     public static final String PRETTY_COMMA_DELIMITER = "," + SINGLE_WHITESPACE;
-    public static final String PRETTY_TO_DELIMITER = SINGLE_WHITESPACE + "-" + SINGLE_WHITESPACE;
+    public static final String PRETTY_TO_DELIMITER = SINGLE_WHITESPACE + "-"
+            + SINGLE_WHITESPACE;
 
     // DateTime formatting patterns
     public static final DateTimeFormatter ABRIDGED_DATE_FORMAT = DateTimeFormatter
@@ -234,18 +235,20 @@ public class DateTimeParser {
     public static String extractPrettyDateTime(LocalDateTime ldt) {
         // special case for today/tomorrow relative to local system time
         if (isToday(ldt)) {
-            return TODAY_DATE_REF + PRETTY_COMMA_DELIMITER + extractTwelveHourTime(ldt);
+            return TODAY_DATE_REF + PRETTY_COMMA_DELIMITER
+                    + extractTwelveHourTime(ldt);
         }
 
         if (isTomorrow(ldt)) {
-            return TOMORROW_DATE_REF + PRETTY_COMMA_DELIMITER + extractTwelveHourTime(ldt);
+            return TOMORROW_DATE_REF + PRETTY_COMMA_DELIMITER
+                    + extractTwelveHourTime(ldt);
         }
 
         // add relative prefix (this/next <day of week>) if applicable
         if (computeDaysTo(ldt) < 14) {
             // is within the next two weeks
-            return makeRelativePrefix(ldt) + extractLongDayOfWeek(ldt) + PRETTY_COMMA_DELIMITER
-                    + extractTwelveHourTime(ldt);
+            return makeRelativePrefix(ldt) + extractLongDayOfWeek(ldt)
+                    + PRETTY_COMMA_DELIMITER + extractTwelveHourTime(ldt);
         }
 
         // explicit date; no relative prefix
@@ -257,8 +260,8 @@ public class DateTimeParser {
             // different years in start and end datetimes
             prettyDate = ldt.toLocalDate().format(EXPLICIT_DATE_FORMAT);
         }
-        return extractShortDayOfWeek(ldt) + SINGLE_WHITESPACE + prettyDate + PRETTY_COMMA_DELIMITER
-                + extractTwelveHourTime(ldt);
+        return extractShortDayOfWeek(ldt) + SINGLE_WHITESPACE + prettyDate
+                + PRETTY_COMMA_DELIMITER + extractTwelveHourTime(ldt);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/address/logic/parser/DateTimeParser.java
@@ -26,12 +26,11 @@ public class DateTimeParser {
     // the part of the command that contains the temporal part of the command
     private String datetime;
 
-    // natty parser object
+    // PrettyTimeParser object
     // careful of name collision with our own Parser object
-    // static so we only need to initialize it once
     private static PrettyTimeParser parser = new PrettyTimeParser();
 
-    // prettytime formatter
+    // PrettyTime formatter
     private static PrettyTime prettytime = new PrettyTime();
 
     // result from parser
@@ -39,8 +38,15 @@ public class DateTimeParser {
     private List<Date> dates;
 
     public static final String EMPTY_STRING = "";
+    public static final String SINGLE_WHITESPACE = " ";
+    
+    // handy strings for making pretty dates
     public static final String TODAY_DATE_REF = "Today";
     public static final String TOMORROW_DATE_REF = "Tomorrow";
+    public static final String NEXT_WEEK_REF = "Next" + SINGLE_WHITESPACE;
+    public static final String THIS_WEEK_REF = "This" + SINGLE_WHITESPACE;
+    public static final String PRETTY_COMMA_DELIMITER = "," + SINGLE_WHITESPACE;
+    public static final String PRETTY_TO_DELIMITER = SINGLE_WHITESPACE + "-" + SINGLE_WHITESPACE;
 
     // DateTime formatting patterns
     public static final DateTimeFormatter ABRIDGED_DATE_FORMAT = DateTimeFormatter
@@ -60,7 +66,7 @@ public class DateTimeParser {
 
         this.datetime = input;
 
-        // perform natty parsing
+        // perform parsing
         this.dategroups = DateTimeParser.parser.parseSyntax(input);
         this.dates = DateTimeParser.parser.parse(input);
     }
@@ -119,12 +125,12 @@ public class DateTimeParser {
 
         // is an event with a definite start and end datetime
         if (isSameDay(start, end)) {
-            return extractPrettyDateTime(start) + " - "
+            return extractPrettyDateTime(start) + PRETTY_TO_DELIMITER
                     + extractTwelveHourTime(end);
         }
 
         // not same day
-        return extractPrettyDateTime(start) + " - "
+        return extractPrettyDateTime(start) + PRETTY_TO_DELIMITER
                 + extractPrettyDateTime(end);
     }
 
@@ -228,17 +234,17 @@ public class DateTimeParser {
     public static String extractPrettyDateTime(LocalDateTime ldt) {
         // special case for today/tomorrow relative to local system time
         if (isToday(ldt)) {
-            return TODAY_DATE_REF + ", " + extractTwelveHourTime(ldt);
+            return TODAY_DATE_REF + PRETTY_COMMA_DELIMITER + extractTwelveHourTime(ldt);
         }
 
         if (isTomorrow(ldt)) {
-            return TOMORROW_DATE_REF + ", " + extractTwelveHourTime(ldt);
+            return TOMORROW_DATE_REF + PRETTY_COMMA_DELIMITER + extractTwelveHourTime(ldt);
         }
 
         // add relative prefix (this/next <day of week>) if applicable
         if (computeDaysTo(ldt) < 14) {
             // is within the next two weeks
-            return makeRelativePrefix(ldt) + extractLongDayOfWeek(ldt) + ", "
+            return makeRelativePrefix(ldt) + extractLongDayOfWeek(ldt) + PRETTY_COMMA_DELIMITER
                     + extractTwelveHourTime(ldt);
         }
 
@@ -251,7 +257,7 @@ public class DateTimeParser {
             // different years in start and end datetimes
             prettyDate = ldt.toLocalDate().format(EXPLICIT_DATE_FORMAT);
         }
-        return extractShortDayOfWeek(ldt) + " " + prettyDate + ", "
+        return extractShortDayOfWeek(ldt) + SINGLE_WHITESPACE + prettyDate + PRETTY_COMMA_DELIMITER
                 + extractTwelveHourTime(ldt);
     }
 
@@ -303,9 +309,9 @@ public class DateTimeParser {
      */
     private static String makeRelativePrefix(LocalDateTime ldt) {
         if (computeDaysTo(ldt) < 7) {
-            return "This ";
+            return THIS_WEEK_REF;
         } else if (computeDaysTo(ldt) < 14) {
-            return "Next ";
+            return NEXT_WEEK_REF;
         }
         return EMPTY_STRING;
     }

--- a/src/main/java/seedu/address/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/address/logic/parser/DateTimeParser.java
@@ -86,7 +86,7 @@ public class DateTimeParser {
         assert this.dates != null;
 
         if (this.dates.size() < 2) {
-            return extractStartDate();
+            return null;
         }
 
         return changeDateToLocalDateTime(this.dates.get(1));

--- a/src/main/java/seedu/address/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/address/logic/parser/DateTimeParser.java
@@ -1,7 +1,9 @@
 package seedu.address.logic.parser;
 
+import java.time.DayOfWeek;
 import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.Month;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
@@ -157,7 +159,63 @@ public class DateTimeParser {
         assert this.dates != null;
         return prettytime.format(this.dates.get(index));
     }
-
+    
+    /**
+     * Helper method for determining a human-readable pretty date
+     * from date tokens in the input string
+     * 
+     * This is independent of local system time, although it is
+     * intended for dates that are upcoming in the next 7 days as
+     * only the day of the week is indicated instead of a date.
+     * 
+     * This method does NOT check if the input date is within the
+     * next 7 days.
+     * 
+     * Examples:
+     * "Monday, 6:30AM"
+     * "Saturday, 12:37PM"
+     * 
+     * @param index
+     * @return
+     *      pretty date for this week
+     */
+    private String extractThisWeekPrettyDate(int index) {
+        assert this.dates != null;
+        
+        LocalDateTime ldt = changeDateToLocalDateTime(this.dates.get(index));
+        
+        DayOfWeek day = ldt.getDayOfWeek();
+        int hour = ldt.getHour();
+        int minute = ldt.getMinute();
+        
+        // convert to 12h time from 24h
+        if(hour > 12) {
+            hour = hour%12;
+        }
+        
+        return day.toString() + ", " + hour + ":" + String.format("%02d", minute) + computeMeridian(hour);
+    }
+    
+    /**
+     * Returns the meridian of a given hour
+     * 
+     * Examples:
+     * Returns "PM" if given hour is 23 (11PM)
+     * Returns "AM" if given hour is 11 (11AM)
+     * 
+     * @param hour
+     *      integer hour in 24h format
+     * @return
+     *      meridian of the hour
+     * @author darren
+     */
+    private String computeMeridian(int hour) {
+        if(hour > 12) {
+            return "PM";
+        }
+        return "AM";
+    }
+    
     public DateGroup getDateGroup(int index) {
         return this.dategroups.get(index);
     }

--- a/src/main/java/seedu/address/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/address/logic/parser/DateTimeParser.java
@@ -7,6 +7,7 @@ import java.time.LocalDateTime;
 import java.time.Month;
 import java.time.Period;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
@@ -137,8 +138,7 @@ public class DateTimeParser {
     }
 
     /**
-     * helper method for casting java.util.Date to java.time.LocalDateTime
-     * safely
+     * Helper method for casting java.util.Date to java.time.LocalDateTime
      * 
      * @param date
      * @return
@@ -148,6 +148,18 @@ public class DateTimeParser {
         Instant instant = date.toInstant().truncatedTo(ChronoUnit.SECONDS); // strip
                                                                             // milliseconds
         return LocalDateTime.ofInstant(instant, ZoneId.systemDefault());
+    }
+    
+    /**
+     * Helper method for casting java.time.LocalDateTime to java.util.Date
+     * 
+     * @param ldt
+     * @return
+     * @author darren
+     */
+    public static Date changeLocalDateTimeToDate(LocalDateTime ldt) {
+        Instant instant = ldt.atZone(ZoneId.systemDefault()).toInstant();
+        return Date.from(instant);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/address/logic/parser/DateTimeParser.java
@@ -73,32 +73,6 @@ public class DateTimeParser {
         return changeDateToLocalDateTime(this.dates.get(0));
     }
 
-    /**
-     * Extracts a pretty relative start date
-     * 
-     * Examples of pretty relative dates: (for future dates) "3 weeks from now",
-     * "2 days from now", "12 minutes from now", "moments from now"
-     * 
-     * (for past dates) "3 weeks ago", "2 days ago", "12 minutes ago", "moments
-     * ago"
-     * 
-     * @return
-     * @author darren
-     */
-    public String extractPrettyRelativeStartDateTime() {
-        return extractPrettyRelativeDateTime(0);
-    }
-
-    /**
-     * Extracts a pretty start date
-     * 
-     * @return
-     * @author darren
-     */
-    public String extractPrettyStartDateTime() {
-        return extractPrettyDateTime(0);
-    }
-
     public LocalDateTime extractEndDate() {
         assert this.dates != null;
 
@@ -107,38 +81,6 @@ public class DateTimeParser {
         }
 
         return changeDateToLocalDateTime(this.dates.get(1));
-    }
-
-    /**
-     * Extracts a pretty relative end date
-     * 
-     * Examples of pretty relative dates: (for future dates) "3 weeks from now",
-     * "2 days from now", "12 minutes from now", "moments from now"
-     * 
-     * (for past dates) "3 weeks ago", "2 days ago", "12 minutes ago", "moments
-     * ago"
-     * 
-     * @return
-     * @author darren
-     */
-    public String extractPrettyRelativeEndDateTime() {
-        if (this.dates.size() < 2) {
-            return extractPrettyRelativeStartDateTime();
-        }
-        return extractPrettyRelativeDateTime(1);
-    }
-
-    /**
-     * Extracts a pretty end date
-     * 
-     * @return
-     * @author darren
-     */
-    public String extractPrettyEndDateTime() {
-        if (this.dates.size() < 2) {
-            return extractPrettyStartDateTime();
-        }
-        return extractPrettyDateTime(1);
     }
 
     public boolean isRecurring() {
@@ -159,22 +101,26 @@ public class DateTimeParser {
      * @return
      * @author darren
      */
-    public String extractPrettyItemCardDateTime() {
-        assert this.dates != null;
+    public static String extractPrettyItemCardDateTime(LocalDateTime start, LocalDateTime end) {
+        if(start == null && end == null) {
+            return EMPTY_STRING;
+        }
         
-        if(this.dates.size() < 2) {
-            return extractPrettyStartDateTime();
+        if(start == null) {
+            return extractPrettyDateTime(end);
+        }
+        
+        if(end == null) {
+            return extractPrettyDateTime(start);
         }
         
         // is an event with a definite start and end datetime
-        LocalDateTime start = changeDateToLocalDateTime(this.dates.get(0));
-        LocalDateTime end = changeDateToLocalDateTime(this.dates.get(1));
         if(isSameDay(start, end)) {
-            return extractPrettyStartDateTime() + " - " + extractTwelveHourTime(end);
+            return extractPrettyDateTime(start) + " - " + extractTwelveHourTime(end);
         }
         
         // not same day
-        return extractPrettyDateTime(0) + " - " + extractPrettyDateTime(1);
+        return extractPrettyDateTime(start) + " - " + extractPrettyDateTime(end);
     }
     
     /**
@@ -223,9 +169,8 @@ public class DateTimeParser {
      * @return pretty relative date
      * @author darren
      */
-    private String extractPrettyRelativeDateTime(int index) {
-        assert this.dates != null;
-        return prettytime.format(this.dates.get(index));
+    public static String extractPrettyRelativeDateTime(LocalDateTime ldt) {
+        return null;
     }
 
     /**
@@ -238,11 +183,7 @@ public class DateTimeParser {
      * @param index
      * @return pretty date for this week
      */
-    private String extractPrettyDateTime(int index) {
-        assert this.dates != null;
-
-        LocalDateTime ldt = changeDateToLocalDateTime(this.dates.get(index));
-
+    public static String extractPrettyDateTime(LocalDateTime ldt) {
         // add relative prefix (this/next <day of week>) if applicable
         if(computeDaysTo(ldt) < 14) {
             // is within the next two weeks

--- a/src/main/java/seedu/address/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/address/logic/parser/DateTimeParser.java
@@ -193,7 +193,7 @@ public class DateTimeParser {
             hour = hour%12;
         }
         
-        return day.toString() + ", " + hour + ":" + String.format("%02d", minute) + computeMeridian(hour);
+        return toTitleCase(day.toString()) + ", " + hour + ":" + String.format("%02d", minute) + computeMeridian(hour);
     }
     
     /**
@@ -209,11 +209,28 @@ public class DateTimeParser {
      *      meridian of the hour
      * @author darren
      */
-    private String computeMeridian(int hour) {
+    private static String computeMeridian(int hour) {
         if(hour > 12) {
             return "PM";
         }
         return "AM";
+    }
+    
+    /**
+     * Transforms a String into a title-cased string.
+     * 
+     * The first letter of the string will be uppercase
+     * while every letter after will be lowercase.
+     * 
+     * @param string
+     *      string to be transformed
+     * @return
+     *      s in title case
+     * @author darren
+     */
+    private static String toTitleCase(String string) {
+        return string.substring(0, 1).toUpperCase() +
+                   string.substring(1).toLowerCase();
     }
     
     public DateGroup getDateGroup(int index) {

--- a/src/main/java/seedu/address/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/address/logic/parser/DateTimeParser.java
@@ -39,9 +39,12 @@ public class DateTimeParser {
     
     public static final String EMPTY_STRING = "";
 
+    // DateTime formatting patterns
     public static final DateTimeFormatter ABRIDGED_DATE_FORMAT = DateTimeFormatter.ofPattern("dd MMM");
     public static final DateTimeFormatter EXPLICIT_DATE_FORMAT = DateTimeFormatter.ofPattern("dd MMM yyyy");
     public static final DateTimeFormatter TWELVE_HOUR_TIME = DateTimeFormatter.ofPattern("h:mma");
+    public static final DateTimeFormatter FULL_DAYOFWEEK = DateTimeFormatter.ofPattern("EEEE");
+    public static final DateTimeFormatter SHORT_DAYOFWEEK = DateTimeFormatter.ofPattern("EEE");
 
     public DateTimeParser(String input) {
         assert input != null;
@@ -213,13 +216,10 @@ public class DateTimeParser {
 
         LocalDateTime ldt = changeDateToLocalDateTime(this.dates.get(index));
 
-        String dayOfWeek = toTitleCase(ldt.getDayOfWeek().toString());
-        String dayOfWeekShort = dayOfWeek.substring(0, 3);
-
         // add relative prefix (this/next <day of week>) if applicable
         if(computeDaysTo(ldt) < 14) {
             // is within the next two weeks
-            return makeRelativePrefix(ldt) + dayOfWeek + ", " + extractTwelveHourTime(ldt);
+            return makeRelativePrefix(ldt) + extractDayOfWeek(ldt, true) + ", " + extractTwelveHourTime(ldt);
         }
 
         // explicit date; no relative prefix
@@ -231,7 +231,7 @@ public class DateTimeParser {
             // different years
             prettyDate = ldt.toLocalDate().format(EXPLICIT_DATE_FORMAT);
         }
-        return dayOfWeekShort + " " + prettyDate + ", " + extractTwelveHourTime(ldt);
+        return extractDayOfWeek(ldt, false) + " " + prettyDate + ", " + extractTwelveHourTime(ldt);
     }
 
     /**
@@ -244,6 +244,24 @@ public class DateTimeParser {
      */
     public static String extractTwelveHourTime(LocalDateTime ldt) {
         return ldt.toLocalTime().format(TWELVE_HOUR_TIME);
+    }
+    
+    /**
+     * Extracts the day-of-week component of a java.time.LocalDateTime object
+     * and returns it in long or short format (Monday or Mon)
+     * 
+     * @param ldt
+     * @param isLongFormat
+     *      result is long format?
+     * @return
+     *      day-of-week
+     * @author darren
+     */
+    public static String extractDayOfWeek(LocalDateTime ldt, boolean isLongFormat) {
+        if(isLongFormat) {
+            return ldt.toLocalDate().format(FULL_DAYOFWEEK);
+        }
+        return ldt.toLocalDate().format(SHORT_DAYOFWEEK);
     }
     
     /**
@@ -274,22 +292,6 @@ public class DateTimeParser {
     public static long computeDaysTo(LocalDateTime ldt) {
         assert ldt.isAfter(LocalDateTime.now());
         return ChronoUnit.DAYS.between(LocalDate.now(), ldt.toLocalDate());
-    }
-
-    /**
-     * Transforms a String into a title-cased string.
-     * 
-     * The first letter of the string will be uppercase while every letter after
-     * will be lowercase.
-     * 
-     * @param string
-     *            string to be transformed
-     * @return s in title case
-     * @author darren
-     */
-    public static String toTitleCase(String string) {
-        return string.substring(0, 1).toUpperCase()
-                + string.substring(1).toLowerCase();
     }
 
     public DateGroup getDateGroup(int index) {

--- a/src/main/java/seedu/address/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/address/logic/parser/DateTimeParser.java
@@ -59,6 +59,20 @@ public class DateTimeParser {
         return changeDateToLocalDateTime(this.dates.get(0));
     }
     
+    /**
+     * Extracts a pretty relative start date
+     * 
+     * Examples of pretty relative dates:
+     * (for future dates)
+     * "3 weeks from now", "2 days from now", "12 minutes from now",
+     * "moments from now"
+     * 
+     * (for past dates)
+     * "3 weeks ago", "2 days ago", "12 minutes ago",
+     * "moments ago"
+     * @return
+     * @author darren
+     */
     public String extractPrettyRelativeStartDate() {
         return extractPrettyRelativeDate(0);
     }
@@ -73,6 +87,20 @@ public class DateTimeParser {
         return changeDateToLocalDateTime(this.dates.get(1));
     }
 
+    /**
+     * Extracts a pretty relative start date
+     * 
+     * Examples of pretty relative dates:
+     * (for future dates)
+     * "3 weeks from now", "2 days from now", "12 minutes from now",
+     * "moments from now"
+     * 
+     * (for past dates)
+     * "3 weeks ago", "2 days ago", "12 minutes ago",
+     * "moments ago"
+     * @return
+     * @author darren
+     */
     public String extractPrettyRelativeEndDate() {
         if (this.dates.size() < 2) {
             return extractPrettyRelativeStartDate();

--- a/src/main/java/seedu/address/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/address/logic/parser/DateTimeParser.java
@@ -182,6 +182,9 @@ public class DateTimeParser {
      * @author darren
      */
     public static String extractPrettyRelativeDateTime(LocalDateTime ldt) {
+        if(ldt == null) {
+            return EMPTY_STRING;
+        }
         return prettytime.format(changeLocalDateTimeToDate(ldt));
     }
 

--- a/src/main/java/seedu/address/model/item/Item.java
+++ b/src/main/java/seedu/address/model/item/Item.java
@@ -134,6 +134,23 @@ public class Item extends Observable implements ReadOnlyItem, Comparable<Item> {
     }
 
 	/**
+	 * Returns the type of the item. Useful for Item cards and messages.
+	 * 
+	 * @return The type of the item, computed based on start/end dates.
+	 *         [Event|Floating Task|Task]
+	 * @@author A0092390E
+	 */
+	public String getType() {
+		if (this.getStartDate() != null) {
+			return "Event";
+		} else if (this.getEndDate() == null) {
+			return "Floating Task";
+		} else {
+			return "Task";
+		}
+	}
+
+	/**
 	 * Replaces this Item's tags with the tags in the argument tag list.
 	 */
     public void setTags(UniqueTagList replacement) {
@@ -260,7 +277,8 @@ public class Item extends Observable implements ReadOnlyItem, Comparable<Item> {
      * @return
      * @author darren
      */
-    public String extractPrettyItemCardDateTime() {
+    @Override
+	public String extractPrettyItemCardDateTime() {
         return DateTimeParser.extractPrettyItemCardDateTime(this.startDate, this.endDate);
     }
     
@@ -298,7 +316,8 @@ public class Item extends Observable implements ReadOnlyItem, Comparable<Item> {
      * @return EMPTY_STRING if datetime is null
      * @author darren
      */
-    public String extractPrettyRelativeEndDateTime() {
+    @Override
+	public String extractPrettyRelativeEndDateTime() {
         if(this.endDate == null) {
             return extractPrettyRelativeStartDateTime();
         }

--- a/src/main/java/seedu/address/model/item/Item.java
+++ b/src/main/java/seedu/address/model/item/Item.java
@@ -7,6 +7,7 @@ import java.util.Observable;
 
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.commons.util.CollectionUtil;
+import seedu.address.logic.parser.DateTimeParser;
 import seedu.address.model.tag.UniqueTagList;
 
 /**
@@ -230,5 +231,36 @@ public class Item extends Observable implements ReadOnlyItem, Comparable<Item> {
         }
         
         return checkee;
+    }
+    
+    /**
+     * Builds a pretty datetime line for this Item's card on the UI.
+     * 
+     * Nulls are handled by DateTimeParser.extractPrettyItemCardDateTime
+     * @return
+     * @author darren
+     */
+    public String extractPrettyItemCardDateTime() {
+        return DateTimeParser.extractPrettyItemCardDateTime(this.startDate, this.endDate);
+    }
+    
+    /**
+     * Gets the pretty relative datetime for this Item's start datetime
+     * e.g. "3 weeks from now"
+     * @return EMPTY_STRING if datetime is null
+     * @author darren
+     */
+    public String extractPrettyRelativeStartDateTime() {
+        return DateTimeParser.extractPrettyRelativeDateTime(this.startDate);
+    }
+
+    /**
+     * Gets the pretty relative datetime for this Item's end datetime
+     * e.g. "3 weeks from now"
+     * @return EMPTY_STRING if datetime is null
+     * @author darren
+     */
+    public String extractPrettyRelativeEndDateTime() {
+        return DateTimeParser.extractPrettyRelativeDateTime(this.endDate);
     }
 }

--- a/src/main/java/seedu/address/model/item/Item.java
+++ b/src/main/java/seedu/address/model/item/Item.java
@@ -112,10 +112,30 @@ public class Item extends Observable implements ReadOnlyItem, Comparable<Item> {
     public LocalDateTime getRecurEndDate() {
         return recurEndDate;
     }
+    
+	/**
+	 * Flexible property querying, to support listing and filtering
+	 * 
+	 * @return boolean, whether the item is or isn't
+	 * @@author A0092390E
+	 */
+    public boolean is(String query){
+    	query = query.toLowerCase();
+		switch (query) {
+		case "done":
+			return this.getIsDone();
+		case "event":
+			return this.getStartDate() != null;
+		case "task":
+			return this.getStartDate() == null;
+		default:
+			return false;
+		}
+    }
 
-    /**
-     * Replaces this Item's tags with the tags in the argument tag list.
-     */
+	/**
+	 * Replaces this Item's tags with the tags in the argument tag list.
+	 */
     public void setTags(UniqueTagList replacement) {
         tags.setTags(replacement);
 		setChanged();

--- a/src/main/java/seedu/address/model/item/Item.java
+++ b/src/main/java/seedu/address/model/item/Item.java
@@ -245,6 +245,24 @@ public class Item extends Observable implements ReadOnlyItem, Comparable<Item> {
     }
     
     /**
+     * Gets the pretty explicit datetime for this Item's start datetime
+     * e.g. "This Monday, 7:30PM" or "Mon 27 Nov, 9:30AM"
+     * @return
+     */
+    public String extractPrettyStartDateTime() {
+        return DateTimeParser.extractPrettyDateTime(this.startDate);
+    }
+
+    /**
+     * Gets the pretty explicit datetime for this Item's end datetime
+     * e.g. "This Monday, 7:30PM" or "Mon 27 Nov, 9:30AM"
+     * @return
+     */
+    public String extractPrettyEndDateTime() {
+        return DateTimeParser.extractPrettyDateTime(this.endDate);
+    }
+    
+    /**
      * Gets the pretty relative datetime for this Item's start datetime
      * e.g. "3 weeks from now"
      * @return EMPTY_STRING if datetime is null

--- a/src/main/java/seedu/address/model/item/Item.java
+++ b/src/main/java/seedu/address/model/item/Item.java
@@ -279,6 +279,9 @@ public class Item extends Observable implements ReadOnlyItem, Comparable<Item> {
      * @author darren
      */
     public String extractPrettyRelativeEndDateTime() {
+        if(this.endDate == null) {
+            return extractPrettyRelativeStartDateTime();
+        }
         return DateTimeParser.extractPrettyRelativeDateTime(this.endDate);
     }
 }

--- a/src/main/java/seedu/address/model/item/ReadOnlyItem.java
+++ b/src/main/java/seedu/address/model/item/ReadOnlyItem.java
@@ -82,4 +82,6 @@ public interface ReadOnlyItem {
 	public void addObserver(Observer o);
 
 	String extractPrettyItemCardDateTime();
+
+	String extractPrettyRelativeEndDateTime();
 }

--- a/src/main/java/seedu/address/model/item/ReadOnlyItem.java
+++ b/src/main/java/seedu/address/model/item/ReadOnlyItem.java
@@ -80,4 +80,6 @@ public interface ReadOnlyItem {
 	}
 
 	public void addObserver(Observer o);
+
+	String extractPrettyItemCardDateTime();
 }

--- a/src/main/java/seedu/address/ui/ItemCard.java
+++ b/src/main/java/seedu/address/ui/ItemCard.java
@@ -28,6 +28,8 @@ public class ItemCard extends UiPart implements Observer {
 	private Text id;
 	@FXML
 	private Text dates;
+	@FXML
+	private Text relativeDate;
 
 	private ReadOnlyItem item;
     private int displayedIndex;
@@ -51,6 +53,7 @@ public class ItemCard extends UiPart implements Observer {
 		description.setText(this.item.getDescription().getFullDescription());
         id.setText(displayedIndex + ". ");
 		dates.setText(item.extractPrettyItemCardDateTime());
+		relativeDate.setText(item.extractPrettyRelativeEndDateTime());
     }
 
     public HBox getLayout() {

--- a/src/main/java/seedu/address/ui/ItemCard.java
+++ b/src/main/java/seedu/address/ui/ItemCard.java
@@ -26,6 +26,8 @@ public class ItemCard extends UiPart implements Observer {
 	private Text type;
 	@FXML
 	private Text id;
+	@FXML
+	private Text dates;
 
 	private ReadOnlyItem item;
     private int displayedIndex;
@@ -48,6 +50,7 @@ public class ItemCard extends UiPart implements Observer {
 		tags.getChildren().addAll(this.getTypeLabel());
 		description.setText(this.item.getDescription().getFullDescription());
         id.setText(displayedIndex + ". ");
+		dates.setText(item.extractPrettyItemCardDateTime());
     }
 
     public HBox getLayout() {

--- a/src/main/resources/view/ItemListCard.fxml
+++ b/src/main/resources/view/ItemListCard.fxml
@@ -34,7 +34,8 @@
                             </children>
                         </HBox>
 	                    <Text fx:id="dates">
-	                    
+	                    </Text>
+	                    <Text fx:id="relativeDate">
 	                    </Text>
                     </children>
                 </VBox>

--- a/src/main/resources/view/ItemListCard.fxml
+++ b/src/main/resources/view/ItemListCard.fxml
@@ -33,6 +33,9 @@
                                 </HBox>
                             </children>
                         </HBox>
+	                    <Text fx:id="dates">
+	                    
+	                    </Text>
                     </children>
                 </VBox>
             </children>

--- a/src/test/java/seedu/address/logic/parser/DateTimeParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DateTimeParserTest.java
@@ -170,4 +170,18 @@ public class DateTimeParserTest {
         assertEquals(expected, DateTimeParser.extractTwelveHourTime(evening));
     }
     
+    @Test
+    public void isSameDayTest_Positive() {
+        LocalDateTime ldt1 = LocalDateTime.of(2016, 11, 11, 11, 11);
+        LocalDateTime ldt2 = LocalDateTime.of(2016, 11, 11, 19, 46);
+        assertEquals(true, DateTimeParser.isSameDay(ldt1, ldt2));
+    }
+
+    @Test
+    public void isSameDayTest_Negative() {
+        LocalDateTime ldt1 = LocalDateTime.of(2016, 11, 11, 11, 11);
+        LocalDateTime ldt2 = LocalDateTime.of(2016, 11, 15, 19, 46);
+        assertEquals(false, DateTimeParser.isSameDay(ldt1, ldt2));
+    }
+    
 }

--- a/src/test/java/seedu/address/logic/parser/DateTimeParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DateTimeParserTest.java
@@ -66,10 +66,8 @@ public class DateTimeParserTest {
 
         LocalDateTime deadline = LocalDateTime.of(LocalDate.of(1996, 11, 12), LocalTime.of(17, 0));
 
-        // extractStartDate and extractEndDate return the same thing if there's only
-        // one date token inside the input string
         assertEquals(deadline, parser.extractStartDate());
-        assertEquals(deadline, parser.extractEndDate());
+        assertEquals(null, parser.extractEndDate());
     }
     
     public static Date makeDate(int year, int month, int day, int hour, int minute) {

--- a/src/test/java/seedu/address/logic/parser/DateTimeParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DateTimeParserTest.java
@@ -72,6 +72,13 @@ public class DateTimeParserTest {
         assertEquals(deadline, parser.extractEndDate());
     }
     
+    public static Date makeDate(int year, int month, int day, int hour, int minute) {
+        Calendar cal = Calendar.getInstance();
+        cal.clear();
+        cal.set(year, month-1, day, hour, minute); //month-1 because Calendar treats JANUARY as 0
+        return cal.getTime();
+    }
+
     @Test
     public void changeDateToLocalDateTimeTest() {
         int year = 2016;
@@ -80,10 +87,7 @@ public class DateTimeParserTest {
         int hour = 17;
         int minute = 0;
 
-        Calendar cal = Calendar.getInstance();
-        cal.clear();
-        cal.set(year, month-1, day, hour, minute); //month-1 because Calendar treats JANUARY as 0
-        Date date = cal.getTime();
+        Date date = makeDate(year, month, day, hour, minute);
 
         LocalDateTime answer = LocalDateTime.of(LocalDate.of(year, month, day), LocalTime.of(hour, minute));
         
@@ -98,10 +102,7 @@ public class DateTimeParserTest {
         int hour = 17;
         int minute = 0;
 
-        Calendar cal = Calendar.getInstance();
-        cal.clear();
-        cal.set(year, month-1, day, hour, minute); //month-1 because Calendar treats JANUARY as 0
-        Date date = cal.getTime();
+        Date date = makeDate(year, month, day, hour, minute);
 
         LocalDateTime ldt = LocalDateTime.of(LocalDate.of(year, month, day), LocalTime.of(hour, minute));
         

--- a/src/test/java/seedu/address/logic/parser/DateTimeParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DateTimeParserTest.java
@@ -74,7 +74,7 @@ public class DateTimeParserTest {
     
     @Test
     public void changeDateToLocalDateTimeTest() {
-        int year = 1996;
+        int year = 2016;
         int month = 11;
         int day = 12;
         int hour = 17;
@@ -88,6 +88,24 @@ public class DateTimeParserTest {
         LocalDateTime answer = LocalDateTime.of(LocalDate.of(year, month, day), LocalTime.of(hour, minute));
         
         assertEquals(answer, DateTimeParser.changeDateToLocalDateTime(date));
+    }
+
+    @Test
+    public void changeLocalDateTimeToDateTest() {
+        int year = 2016;
+        int month = 11;
+        int day = 12;
+        int hour = 17;
+        int minute = 0;
+
+        Calendar cal = Calendar.getInstance();
+        cal.clear();
+        cal.set(year, month-1, day, hour, minute); //month-1 because Calendar treats JANUARY as 0
+        Date date = cal.getTime();
+
+        LocalDateTime ldt = LocalDateTime.of(LocalDate.of(year, month, day), LocalTime.of(hour, minute));
+        
+        assertEquals(date, DateTimeParser.changeLocalDateTimeToDate(ldt));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/DateTimeParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DateTimeParserTest.java
@@ -155,4 +155,19 @@ public class DateTimeParserTest {
         String expected = "6:31PM";
         assertEquals(expected, DateTimeParser.extractTwelveHourTime(evening));
     }
+    
+    @Test
+    public void extractTwelveHourTimeTest_Midnight() {
+        LocalDateTime evening = LocalDateTime.of(2016, 11, 11, 0, 0);
+        String expected = "12:00AM";
+        assertEquals(expected, DateTimeParser.extractTwelveHourTime(evening));
+    }
+
+    @Test
+    public void extractTwelveHourTimeTest_Midday() {
+        LocalDateTime evening = LocalDateTime.of(2016, 11, 11, 12, 0);
+        String expected = "12:00PM";
+        assertEquals(expected, DateTimeParser.extractTwelveHourTime(evening));
+    }
+    
 }

--- a/src/test/java/seedu/address/logic/parser/DateTimeParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DateTimeParserTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertEquals;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
 
@@ -107,4 +108,37 @@ public class DateTimeParserTest {
         assertEquals(false, parser.isRecurring());
     }
     
+    private static ArrayList<LocalDateTime> generateWeeklyLDTs() {
+        LocalDateTime day = LocalDateTime.of(2016, 10, 17, 12, 0); // Monday
+        ArrayList<LocalDateTime> week = new ArrayList<LocalDateTime>();
+
+        week.add(day);
+        
+        for(int i = 0; i < 6; i++) {
+            day = day.plusDays(1);
+            week.add(day);
+        }
+        
+        return week;
+    }
+    
+    @Test
+    public void extractLongDayOfWeekTest() {
+        ArrayList<LocalDateTime> weekLDTs = generateWeeklyLDTs();
+        String[] daysOfWeek = {"Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"};
+        
+        for(int i = 0; i < 7; i++) {
+            assertEquals(daysOfWeek[i], DateTimeParser.extractLongDayOfWeek(weekLDTs.get(i)));
+        }
+    }
+    
+    @Test
+    public void extractShortDayOfWeekTest() {
+        ArrayList<LocalDateTime> weekLDTs = generateWeeklyLDTs();
+        String[] daysOfWeek = {"Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"};
+        
+        for(int i = 0; i < 7; i++) {
+            assertEquals(daysOfWeek[i], DateTimeParser.extractShortDayOfWeek(weekLDTs.get(i)));
+        }
+    }
 }

--- a/src/test/java/seedu/address/logic/parser/DateTimeParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DateTimeParserTest.java
@@ -141,4 +141,18 @@ public class DateTimeParserTest {
             assertEquals(daysOfWeek[i], DateTimeParser.extractShortDayOfWeek(weekLDTs.get(i)));
         }
     }
+    
+    @Test
+    public void extractTwelveHourTimeTest_Morning() {
+        LocalDateTime morning = LocalDateTime.of(2016, 11, 11, 11, 11);
+        String expected = "11:11AM";
+        assertEquals(expected, DateTimeParser.extractTwelveHourTime(morning));
+    }
+
+    @Test
+    public void extractTwelveHourTimeTest_Evening() {
+        LocalDateTime evening = LocalDateTime.of(2016, 11, 11, 18, 31);
+        String expected = "6:31PM";
+        assertEquals(expected, DateTimeParser.extractTwelveHourTime(evening));
+    }
 }


### PR DESCRIPTION
# For @yyc /whoever is doing UI

You should only use the `extractPretty...` methods in `Item` and not have to touch the static methods in `DateTimeParser`.

For making the datetime string in the Item card, use the `Item.extractPrettyItemCardDateTime()` method. Literally just print whatever comes out of that method. It can return an empty string if the `Item` has nulls for `startDate` and `endDate`. It can take the following forms:

``` bash
# if start/end are within two weeks from system time
This Monday, 9:30PM
This Saturday, 9:30PM - 10:30PM
Next Monday, 9:30PM
Next Saturday, 9:30PM - 10:30PM
This Sunday, 10:31AM - Next Monday, 7:30PM

# if start/end are at least two weeks away from system time
Sun 25 Dec, 4:31AM
Sun 25 Dec, 12:37AM - Tue 27 Dec, 10:00PM

# if start and end dates are at least a year apart 
Sun 25 Dec 2016, 12:37AM - Tue 27 Dec 2017, 10:00PM
```

For making the relative date, use `Item.extractPrettyRelativeEndDateTime()`. It can take the following forms:

``` bash
# for dates in the future
moments from now
3 minutes from now
2 days from now
1 week from now
1 month from now

# for dates in the past
moments ago
3 minutes ago
2 days ago
1 week ago
1 month ago
```
# Tests

Tests are not fully implemented for all the pretty datetime extractors as they rely on relative datetimes. I have not figured out how to freeze/mock the system time yet. I have implemented tests for the helper functions in `DateTimeParser` where ever possible.

Fixes #57 
