### PR TITLE
Updates to finding, listing and sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Build Status](https://travis-ci.org/CS2103AUG2016-F11-C3/main.svg?branch=master)](https://travis-ci.org/CS2103AUG2016-F11-C3/main) [![Coverage Status](https://coveralls.io/repos/github/CS2103AUG2016-F11-C3/main/badge.svg?branch=master)](https://coveralls.io/github/CS2103AUG2016-F11-C3/main?branch=fix-find-and-sort)
 # Sudowudo
 
 ### User Interface

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/CS2103AUG2016-F11-C3/main.svg?branch=master)](https://travis-ci.org/CS2103AUG2016-F11-C3/main) [![Coverage Status](https://coveralls.io/repos/github/CS2103AUG2016-F11-C3/main/badge.svg?branch=master)](https://coveralls.io/github/CS2103AUG2016-F11-C3/main?branch=fix-find-and-sort)
+[![Build Status](https://travis-ci.org/CS2103AUG2016-F11-C3/main.svg?branch=master)](https://travis-ci.org/CS2103AUG2016-F11-C3/main) [![Coverage Status](https://coveralls.io/repos/github/CS2103AUG2016-F11-C3/main/badge.svg?branch=master)](https://coveralls.io/github/CS2103AUG2016-F11-C3/main?branch=fix-find-and-sort) [![Codacy Badge](https://api.codacy.com/project/badge/Grade/c17da85aa331442d847cb869771ecafb)](https://www.codacy.com/app/heycraa/main?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=CS2103AUG2016-F11-C3/main&amp;utm_campaign=Badge_Grade)
 # Sudowudo
 
 ### User Interface

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/CS2103AUG2016-F11-C3/main.svg?branch=master)](https://travis-ci.org/CS2103AUG2016-F11-C3/main) [![Coverage Status](https://coveralls.io/repos/github/CS2103AUG2016-F11-C3/main/badge.svg?branch=master)](https://coveralls.io/github/CS2103AUG2016-F11-C3/main?branch=fix-find-and-sort) [![Codacy Badge](https://api.codacy.com/project/badge/Grade/c17da85aa331442d847cb869771ecafb)](https://www.codacy.com/app/heycraa/main?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=CS2103AUG2016-F11-C3/main&amp;utm_campaign=Badge_Grade)
+[![Build Status](https://travis-ci.org/CS2103AUG2016-F11-C3/main.svg?branch=master)](https://travis-ci.org/CS2103AUG2016-F11-C3/main) [![Coverage Status](https://coveralls.io/repos/github/CS2103AUG2016-F11-C3/main/badge.svg?branch=master)](https://coveralls.io/github/CS2103AUG2016-F11-C3/main) [![Codacy Badge](https://api.codacy.com/project/badge/Grade/c17da85aa331442d847cb869771ecafb)](https://www.codacy.com/app/heycraa/main?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=CS2103AUG2016-F11-C3/main&amp;utm_campaign=Badge_Grade)
 # Sudowudo
 
 ### User Interface

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -9,21 +9,21 @@ public class ListCommand extends Command {
     public static final String MESSAGE_UNDO_FAILURE = "";
 
 
-	public static final String MESSAGE_SUCCESS = "Listed all items of type %1$s";
+	public static final String MESSAGE_SUCCESS = "Listed all %1$s";
     public static final String MESSAGE_INVALID_TYPE = "List argument is invalid";    
     
-    public static final Object MESSAGE_USAGE = COMMAND_WORD + " lists items that match the given parameter "
-            + "Parameter: \"OPTIONAL_TYPE_ARGUMENT (task, event, done, overdue, undone)\" "
+	public static final Object MESSAGE_USAGE = COMMAND_WORD + " lists items that match the given parameter"
+			+ "Parameter: \"OPTIONAL_TYPE_ARGUMENT (task, event, done, overdue, undone)\""
             + "Example: list task";
 
     //@@author A0131560U
     private enum Type{
-        TASK("task", "that are a task"),
-        EVENT("event", "that are an event"), 
-        DONE("done", "that are done"), 
-        ITEM("item", ""), 
-        OVERDUE("overdue", "that are overdue"), 
-        UNDONE("undone", "that are not done");
+        TASK("task", "tasks"),
+        EVENT("event", "events"), 
+        DONE("done", "completed tasks"), 
+        ITEM("item", "items"), 
+        OVERDUE("overdue", "overdue tasks"), 
+        UNDONE("undone", "undone tasks");
         
         private String typeName;
         private String typeMessage;
@@ -50,6 +50,11 @@ public class ListCommand extends Command {
         public Object getTypeMessage() {
             return this.typeMessage;
         }
+
+		@Override
+		public String toString() {
+			return this.typeMessage;
+		}
     }
 
     private Type itemType;

--- a/src/main/java/seedu/address/logic/parser/Parser.java
+++ b/src/main/java/seedu/address/logic/parser/Parser.java
@@ -31,6 +31,7 @@ import seedu.address.logic.commands.IncorrectCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.SelectCommand;
 import seedu.address.logic.commands.UndoCommand;
+import seedu.address.model.item.Item;
 
 /**
  * Parses user input.
@@ -68,23 +69,6 @@ public class Parser {
     private static final Pattern COMMAND_TAG_SEARCH_FORMAT = Pattern.compile("#([^ ]+)");
     
     private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
-
-	
-    //@@author A0131560U
-	private enum Type {
-	    TASK("task"), EVENT("event"), DONE("done"), ITEM("item"), OVERDUE("overdue"), UNDONE("undone");
-	    
-        private String typeName;
-
-        Type(String name) {
-            this.typeName = name;
-        }
-
-        public String getTypeName() {
-            return this.typeName;
-        }
-	}
-	//@@author
 
     public enum Field {
         NAME("name"),
@@ -171,7 +155,7 @@ public class Parser {
     private Command prepareList(String argument) {
         assert argument != null;
         if (argument.isEmpty()){
-            return new ListCommand(Type.ITEM.getTypeName());
+            return new ListCommand(Item.Type.ITEM.getTypeName());
         }
         else if (isValidType(argument)){
             return new ListCommand(argument.trim().toLowerCase());
@@ -187,10 +171,10 @@ public class Parser {
      * @return true if String is valid Type, false otherwise
      * @@author A0131560U
      */
-    private boolean isValidType(String argument) {
+    public static boolean isValidType(String argument) {
         assert argument != null;
         try{
-            Type.valueOf(argument.trim().toUpperCase());
+            Item.Type.valueOf(argument.trim().toUpperCase());
         } catch (IllegalArgumentException iae) {
             return false;
         }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -245,6 +245,11 @@ public class ModelManager extends ComponentManager implements Model {
     }
 
     //@@author A0131560U
+    /**
+     * A Qualifier class that particularly checks for Item Type (e.g. Task, Event, Done).
+     * @author craa
+     *
+     */
     private class TypeQualifier implements Qualifier {
         private String type;
 
@@ -268,6 +273,11 @@ public class ModelManager extends ComponentManager implements Model {
     }
 
     //@@author A0131560U
+    /**
+     * A Qualifier class that particularly checks a set of keywords.
+     * @author craa
+     *
+     */
     private class KeywordQualifier implements Qualifier {
         private Set<String> searchKeyWords;
 
@@ -278,7 +288,7 @@ public class ModelManager extends ComponentManager implements Model {
         @Override
         public boolean run(ReadOnlyItem item) {
             for (String keyword : searchKeyWords) {
-                if (!new Keyword(keyword).search(item)) {
+                if (!new Keyword(keyword).matches(item)) {
                     return false;
                 }
             }
@@ -292,9 +302,10 @@ public class ModelManager extends ComponentManager implements Model {
     }
 
     // @@author A0092390E-idea
-    //@@author A0131560U
     /**
-     * Given an item, returns true if the item matches this keyword, and false otherwise.
+     * An anonymous class that holds a keyword. This keyword is used to search against items.
+     * @author craa
+     *
      */
     private class Keyword {
         private String keyword;
@@ -303,7 +314,13 @@ public class ModelManager extends ComponentManager implements Model {
             keyword = _keyword;
         }
 
-        public boolean search(ReadOnlyItem item) {
+        //@@author A0131560U
+        /**
+         * Returns true if the item matches the keyword in this instance of Keyword.
+         * @param item
+         * @return
+         */
+        public boolean matches(ReadOnlyItem item) {
             if (keyword.matches(Parser.COMMAND_DESCRIPTION_REGEX)) {
                 return matchesDescription(item);
             } else if (keyword.matches(Parser.COMMAND_TAG_REGEX)) {
@@ -313,6 +330,11 @@ public class ModelManager extends ComponentManager implements Model {
             }
         }
 
+        /**
+         * Checks if the item's start or end date matches the keyword.
+         * @param item
+         * @return
+         */
         private boolean matchesDates(ReadOnlyItem item) {
             DateTimeParser parseDate = new DateTimeParser(keyword);
             return ((item.getStartDate() != null
@@ -321,11 +343,21 @@ public class ModelManager extends ComponentManager implements Model {
                             && DateTimeParser.isSameDay(item.getEndDate(), parseDate.extractStartDate()))));
         }
 
+        /**
+         * Checks if the item's tags match the keyword.
+         * @param item
+         * @return
+         */
         private boolean matchesTags(ReadOnlyItem item) {
             return StringUtil.containsIgnoreCase(item.getTags().listTags(),
                     keyword.replaceFirst(Parser.COMMAND_TAG_PREFIX, ""));
         }
 
+        /**
+         * Checks if the item's description matches the keyword
+         * @param item
+         * @return
+         */
         private boolean matchesDescription(ReadOnlyItem item) {
             return StringUtil.containsIgnoreCase(item.getDescription().getFullDescription(),
                     keyword.replace(Parser.COMMAND_DESCRIPTION_PREFIX, ""));

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -344,13 +344,18 @@ public class ModelManager extends ComponentManager implements Model {
         }
 
         /**
-         * Checks if the item's tags match the keyword.
+         * Checks if the item's tags (or types, if the tag string actually
+         * aliases to a type meta-tag) match the keyword.
          * @param item
          * @return
          */
         private boolean matchesTags(ReadOnlyItem item) {
-            return StringUtil.containsIgnoreCase(item.getTags().listTags(),
-                    keyword.replaceFirst(Parser.COMMAND_TAG_PREFIX, ""));
+            keyword = keyword.replaceFirst(Parser.COMMAND_TAG_PREFIX, "");
+            if (isKeywordType()){
+                return item.is(keyword);
+            }
+
+            return StringUtil.containsIgnoreCase(item.getTags().listTags(),keyword);
         }
 
         /**
@@ -361,6 +366,10 @@ public class ModelManager extends ComponentManager implements Model {
         private boolean matchesDescription(ReadOnlyItem item) {
             return StringUtil.containsIgnoreCase(item.getDescription().getFullDescription(),
                     keyword.replace(Parser.COMMAND_DESCRIPTION_PREFIX, ""));
+        }
+        
+        private boolean isKeywordType(){
+            return Parser.isValidType(keyword);
         }
     }
 

--- a/src/main/java/seedu/address/model/item/Item.java
+++ b/src/main/java/seedu/address/model/item/Item.java
@@ -17,14 +17,24 @@ import seedu.address.model.tag.UniqueTagList;
  * 
  */
 public class Item extends Observable implements ReadOnlyItem, Comparable<Item> {
+    
+    //@@author A0131560U
+    public enum Type {
+        TASK("task"), EVENT("event"), DONE("done"), ITEM("item"), OVERDUE("overdue"), UNDONE("undone");
+        
+        private String typeName;
 
-    public static final Comparator<Item> chronologicalComparator = new Comparator<Item>(){
-        @Override
-        public int compare(Item x, Item y) {
-            return x.compareTo(y);
+        Type(String name) {
+            this.typeName = name;
         }
-    };
-;
+
+        public String getTypeName() {
+            return this.typeName;
+        }
+    }
+    //@@author
+
+    
     private UniqueTagList tags;
     private Description description;
     private boolean isDone;
@@ -399,4 +409,11 @@ public class Item extends Observable implements ReadOnlyItem, Comparable<Item> {
         return DateTimeParser.extractPrettyRelativeDateTime(this.endDate);
     }
     //@@author
+    
+    public static final Comparator<Item> chronologicalComparator = new Comparator<Item>(){
+        @Override
+        public int compare(Item x, Item y) {
+            return x.compareTo(y);
+        }
+    };
 }

--- a/src/main/java/seedu/address/model/item/Item.java
+++ b/src/main/java/seedu/address/model/item/Item.java
@@ -173,8 +173,8 @@ public class Item extends Observable implements ReadOnlyItem, Comparable<Item> {
 		case "task":
 			return this.getStartDate() == null;
 		case "overdue":
-			return this.getEndDate() != null && this.getIsDone() == false
-					&& this.getEndDate().isAfter(LocalDateTime.now());
+			return this.is("task") && this.getEndDate() != null 
+			        && this.getEndDate().isBefore(LocalDateTime.now());
 		case "item":
 		    return true;
 		default:

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -2,6 +2,7 @@ package seedu.address.model.tag;
 
 
 import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.logic.parser.Parser;
 
 /**
  * Represents a Tag in the address book.
@@ -9,7 +10,8 @@ import seedu.address.commons.exceptions.IllegalValueException;
  */
 public class Tag {
 
-    public static final String MESSAGE_TAG_CONSTRAINTS = "Tags names should be alphanumeric";
+    public static final String MESSAGE_TAG_CONSTRAINTS = "Tags names should be alphanumeric and"
+            + " cannot be the following words: \'done\', \'event\', \'task\', \'overdue\', \'(un)done\'";
     public static final String TAG_VALIDATION_REGEX = "\\p{Alnum}+";
 
     public String tagName;
@@ -33,9 +35,12 @@ public class Tag {
 
     /**
      * Returns true if a given string is a valid tag name.
+     * The tag must be alphanumeric, and cannot take the name of a type meta-tag,
+     * e.g. Event, Task, Done
      */
     public static boolean isValidTagName(String test) {
-        return test.matches(TAG_VALIDATION_REGEX);
+        return test.matches(TAG_VALIDATION_REGEX) &&
+                !Parser.isValidType(test);
     }
 
     @Override

--- a/src/test/java/guitests/CommandBoxTest.java
+++ b/src/test/java/guitests/CommandBoxTest.java
@@ -7,16 +7,13 @@ import static org.junit.Assert.assertEquals;
 public class CommandBoxTest extends TaskBookGuiTest {
 
     @Test
-    public void commandBox_commandSucceeds_textCleared() {
+    public void commandBox_commandEntered_textCleared() {
         commandBox.runCommand(td.bags.getAddCommand());
         assertEquals(commandBox.getCommandInput(), "");
-    }
-
-    @Test
-    public void commandBox_commandFails_textStays(){
         commandBox.runCommand("invalid command");
-        assertEquals(commandBox.getCommandInput(), "invalid command");
-        //TODO: confirm the text box color turns to red
-    }
+        assertEquals("",commandBox.getCommandInput());
 
+    }
+    
+    //TODO: Write negative tests
 }

--- a/src/test/java/guitests/UndoCommandTest.java
+++ b/src/test/java/guitests/UndoCommandTest.java
@@ -44,7 +44,7 @@ public class UndoCommandTest extends TaskBookGuiTest {
 
         // undo should succeed
         commandBox.runCommand("undo");
-        assertResultMessage("Undo delete task: Always brush teeth");
+        assertResultMessage("Undo delete task: Dover Road");
         
         // delete a bad command
         commandBox.runCommand("delete " + currentList.length + 2);

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -282,7 +282,7 @@ public class LogicManagerTest<E> {
 
         // prepare task book state
         helper.addToModel(model, 2);
-        assertCommandBehavior("list", (String.format(ListCommand.MESSAGE_SUCCESS,"")), expectedAB, expectedList);
+        assertCommandBehavior("list", (String.format(ListCommand.MESSAGE_SUCCESS,"ITEM")), expectedAB, expectedList);
     }
     
     @Test
@@ -299,7 +299,7 @@ public class LogicManagerTest<E> {
 
         // prepare task book state
         helper.addToModel(model, 2);
-        assertCommandBehavior("list task", (String.format(ListCommand.MESSAGE_SUCCESS,"that are a task")), expectedTB, expectedList);
+        assertCommandBehavior("list task", (String.format(ListCommand.MESSAGE_SUCCESS,"TASK")), expectedTB, expectedList);
     }
 
     @Test
@@ -325,7 +325,7 @@ public class LogicManagerTest<E> {
 
         // prepare task book state
         helper.addToModel(model, 2);
-        assertCommandBehavior("list", (String.format(ListCommand.MESSAGE_SUCCESS,"")), expectedAB, expectedList);
+        assertCommandBehavior("list", (String.format(ListCommand.MESSAGE_SUCCESS,"ITEM")), expectedAB, expectedList);
     }
     
     @Test
@@ -364,7 +364,7 @@ public class LogicManagerTest<E> {
 
         // prepare task book state
         helper.addToModel(model, 2);
-        assertCommandBehavior("list", (String.format(ListCommand.MESSAGE_SUCCESS,"")), expectedAB, expectedList);
+        assertCommandBehavior("list", (String.format(ListCommand.MESSAGE_SUCCESS,"ITEM")), expectedAB, expectedList);
     }
     
     //@@author
@@ -615,7 +615,7 @@ public class LogicManagerTest<E> {
         TaskBook expectedTB = helper.generateTaskBook(expectedItems);
         helper.addToModel(model, expectedItems);
 
-        assertCommandBehavior("done 2", DoneCommand.MESSAGE_DONE_ITEM_FAIL, expectedTB, expectedItems);
+        assertCommandBehavior("done 1", DoneCommand.MESSAGE_DONE_ITEM_FAIL, expectedTB, expectedItems);
 
     }
     
@@ -672,11 +672,11 @@ public class LogicManagerTest<E> {
         Item p3 = helper.generateItemWithName("key key");
         Item p4 = helper.generateItemWithName("KEy sduauo");
         
-        String newDescription = "walk lion";
+        String newDescription = "ba lion";
         Item modified = helper.generateItemWithName(newDescription);
 
         List<Item> fourItems = helper.generateItemList(p3, p1, p4, p2);
-        List<Item> expectedList = helper.generateItemList(modified, p1, p4, p2);
+        List<Item> expectedList = helper.generateItemList(modified, p3, p4, p2);
         TaskBook expectedTB = helper.generateTaskBook(expectedList);
         helper.addToModel(model, fourItems);
 
@@ -829,7 +829,9 @@ public class LogicManagerTest<E> {
         }
 
         List<Item> generateItemList(Item... items) {
-            return Arrays.asList(items);
+            List<Item> itemList = Arrays.asList(items);
+            Collections.sort(itemList);
+            return itemList;
         }
 
         /**

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -145,17 +145,14 @@ public class LogicManagerTest<E> {
      * @return
      */
     private boolean isListSame(List<? extends ReadOnlyItem> expected, List<? extends ReadOnlyItem> actual){
+
         if (expected.size() != actual.size()){
-            System.out.println("Size is wrong");
             return false;
+
         }
         
         for (int i=0; i<expected.size(); i++){
             assertEquals(expected.get(i), actual.get(i));
-            if (!expected.get(i).equals(actual.get(i))){
-                System.out.println("Expected: " + expected.get(i));
-                System.out.println("Actual: " + actual.get(i));
-            }
         }
         return true;
     }
@@ -290,14 +287,15 @@ public class LogicManagerTest<E> {
     public void execute_listTasks_showsAllTasks() throws Exception {
         // prepare expectations
         TestDataHelper helper = new TestDataHelper();
-        Item event1 = helper.aDeadLine();
-        Item event2 = helper.aLongEvent();
-        Item task = helper.aFloatingTask();
-        List<Item> allItems = helper.generateItemList(event1, event2, task);
-        List<Item> expectedList = helper.generateItemList(task);
+        Item task1 = helper.aDeadLine();
+        Item event = helper.aLongEvent();
+        Item task2 = helper.aFloatingTask();
+        List<Item> allItems = helper.generateItemList(event, task1, task2);
+        List<Item> expectedList = helper.generateItemList(task2, task1);
         TaskBook expectedTB = helper.generateTaskBook(allItems);
 
         // prepare task book state
+        helper.addToModel(model, allItems);
         assertCommandBehavior("list task", (String.format(ListCommand.MESSAGE_SUCCESS,"TASK")), expectedTB, expectedList);
     }
 
@@ -306,12 +304,16 @@ public class LogicManagerTest<E> {
     public void execute_listEvents_showsAllEvents() throws Exception {
         // prepare expectations
         TestDataHelper helper = new TestDataHelper();
-        TaskBook expectedAB = helper.generateTaskBook(2);
-        List<? extends ReadOnlyItem> expectedList = expectedAB.getItemList();
+        Item task1 = helper.aDeadLine();
+        Item event = helper.aLongEvent();
+        Item task2 = helper.aFloatingTask();
+        List<Item> allItems = helper.generateItemList(event, task1, task2);
+        List<Item> expectedList = helper.generateItemList(event);
+        TaskBook expectedTB = helper.generateTaskBook(allItems);
 
         // prepare task book state
-        helper.addToModel(model, 2);
-        assertCommandBehavior("list", (String.format(ListCommand.MESSAGE_SUCCESS,"ITEM")), expectedAB, expectedList);
+        helper.addToModel(model, allItems);
+        assertCommandBehavior("list event", (String.format(ListCommand.MESSAGE_SUCCESS,"EVENT")), expectedTB, expectedList);
     }
 
     @Test
@@ -319,12 +321,18 @@ public class LogicManagerTest<E> {
     public void execute_listDone_showsAllDone() throws Exception {
         // prepare expectations
         TestDataHelper helper = new TestDataHelper();
-        TaskBook expectedAB = helper.generateTaskBook(2);
-        List<? extends ReadOnlyItem> expectedList = expectedAB.getItemList();
+        Item task1 = helper.aDeadLine();
+        task1.setIsDone(true);
+        Item event = helper.aLongEvent();
+        event.setIsDone(true);
+        Item task2 = helper.aFloatingTask();
+        List<Item> allItems = helper.generateItemList(event, task1, task2);
+        List<Item> expectedList = helper.generateItemList(event, task1);
+        TaskBook expectedTB = helper.generateTaskBook(allItems);
 
         // prepare task book state
-        helper.addToModel(model, 2);
-        assertCommandBehavior("list", (String.format(ListCommand.MESSAGE_SUCCESS,"ITEM")), expectedAB, expectedList);
+        helper.addToModel(model, allItems);
+        assertCommandBehavior("list done", (String.format(ListCommand.MESSAGE_SUCCESS,"DONE")), expectedTB, expectedList);
     }
     
     @Test
@@ -332,12 +340,18 @@ public class LogicManagerTest<E> {
     public void execute_listUndone_showsAllUndone() throws Exception {
         // prepare expectations
         TestDataHelper helper = new TestDataHelper();
-        TaskBook expectedAB = helper.generateTaskBook(2);
-        List<? extends ReadOnlyItem> expectedList = expectedAB.getItemList();
+        Item task1 = helper.aDeadLine();
+        task1.setIsDone(true);
+        Item event = helper.aLongEvent();
+        event.setIsDone(true);
+        Item task2 = helper.aFloatingTask();
+        List<Item> allItems = helper.generateItemList(event, task1, task2);
+        List<Item> expectedList = helper.generateItemList(task2);
+        TaskBook expectedTB = helper.generateTaskBook(allItems);
 
         // prepare task book state
-        helper.addToModel(model, 2);
-        assertCommandBehavior("list", (String.format(ListCommand.MESSAGE_SUCCESS,"ITEM")), expectedAB, expectedList);
+        helper.addToModel(model, allItems);
+        assertCommandBehavior("list undone", (String.format(ListCommand.MESSAGE_SUCCESS,"UNDONE")), expectedTB, expectedList);
     }
     
     @Test
@@ -345,25 +359,38 @@ public class LogicManagerTest<E> {
     public void execute_listOverdue_showsAllOverdue() throws Exception {
         // prepare expectations
         TestDataHelper helper = new TestDataHelper();
-        TaskBook expectedAB = helper.generateTaskBook(2);
-        List<? extends ReadOnlyItem> expectedList = expectedAB.getItemList();
+        Item task1 = helper.aDeadLine();
+        task1.setEndDate(LocalDateTime.of(2015, 9, 9, 9, 9));
+        Item event = helper.aLongEvent();
+        event.setEndDate(LocalDateTime.of(2015,10,10,9,9));
+        Item task2 = helper.aFloatingTask();
+        task2.setEndDate(LocalDateTime.of(2020,10,10,10,10));
+        List<Item> allItems = helper.generateItemList(event, task1, task2);
+        List<Item> expectedList = helper.generateItemList(task1);
+        TaskBook expectedTB = helper.generateTaskBook(allItems);
 
         // prepare task book state
-        helper.addToModel(model, 2);
-        assertCommandBehavior("list", (String.format(ListCommand.MESSAGE_SUCCESS,"ITEM")), expectedAB, expectedList);
+        helper.addToModel(model, allItems);
+        assertCommandBehavior("list overdue", (String.format(ListCommand.MESSAGE_SUCCESS,"OVERDUE")), expectedTB, expectedList);
     }
 
     @Test
     //@@author A0131560U
-    public void execute_findAfterListRestricted_showsSpecificItems() throws Exception {
+    public void execute_findWithMetatag_success() throws Exception {
         // prepare expectations
         TestDataHelper helper = new TestDataHelper();
-        TaskBook expectedAB = helper.generateTaskBook(2);
-        List<? extends ReadOnlyItem> expectedList = expectedAB.getItemList();
+        Item task1 = helper.aDeadLine();
+        task1.setIsDone(true);
+        Item event = helper.aLongEvent();
+        event.setIsDone(true);
+        Item task2 = helper.aFloatingTask();
+        List<Item> allItems = helper.generateItemList(event, task1, task2);
+        List<Item> expectedList = helper.generateItemList(task1);
+        TaskBook expectedTB = helper.generateTaskBook(allItems);
 
         // prepare task book state
-        helper.addToModel(model, 2);
-        assertCommandBehavior("list", (String.format(ListCommand.MESSAGE_SUCCESS,"ITEM")), expectedAB, expectedList);
+        helper.addToModel(model, allItems);
+        assertCommandBehavior("find #task \"dead\"", (String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 1)), expectedTB, expectedList);
     }
     
     //@@author
@@ -679,7 +706,7 @@ public class LogicManagerTest<E> {
         TaskBook expectedTB = helper.generateTaskBook(expectedList);
         helper.addToModel(model, fourItems);
 
-        String editInputCommand = "edit 1 desc:" + newDescription;
+        String editInputCommand = "edit 4 desc:" + newDescription;
         String expectedMessage = String.format(EditCommand.MESSAGE_SUCCESS, newDescription);
         assertCommandBehavior(editInputCommand, expectedMessage, expectedTB, expectedList);
     }

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -321,13 +321,13 @@ public class LogicManagerTest<E> {
     public void execute_listDone_showsAllDone() throws Exception {
         // prepare expectations
         TestDataHelper helper = new TestDataHelper();
-        Item task1 = helper.aDeadLine();
-        task1.setIsDone(true);
-        Item event = helper.aLongEvent();
-        event.setIsDone(true);
-        Item task2 = helper.aFloatingTask();
-        List<Item> allItems = helper.generateItemList(event, task1, task2);
-        List<Item> expectedList = helper.generateItemList(event, task1);
+        Item done1 = helper.aDeadLine();
+        done1.setIsDone(true);
+        Item done2 = helper.aLongEvent();
+        done2.setIsDone(true);
+        Item undone = helper.aFloatingTask();
+        List<Item> allItems = helper.generateItemList(done2, done1, undone);
+        List<Item> expectedList = helper.generateItemList(done2, done1);
         TaskBook expectedTB = helper.generateTaskBook(allItems);
 
         // prepare task book state
@@ -340,13 +340,13 @@ public class LogicManagerTest<E> {
     public void execute_listUndone_showsAllUndone() throws Exception {
         // prepare expectations
         TestDataHelper helper = new TestDataHelper();
-        Item task1 = helper.aDeadLine();
-        task1.setIsDone(true);
-        Item event = helper.aLongEvent();
-        event.setIsDone(true);
-        Item task2 = helper.aFloatingTask();
-        List<Item> allItems = helper.generateItemList(event, task1, task2);
-        List<Item> expectedList = helper.generateItemList(task2);
+        Item done1 = helper.aDeadLine();
+        done1.setIsDone(true);
+        Item done2 = helper.aLongEvent();
+        done2.setIsDone(true);
+        Item undone = helper.aFloatingTask();
+        List<Item> allItems = helper.generateItemList(done2, done1, undone);
+        List<Item> expectedList = helper.generateItemList(undone);
         TaskBook expectedTB = helper.generateTaskBook(allItems);
 
         // prepare task book state
@@ -359,14 +359,14 @@ public class LogicManagerTest<E> {
     public void execute_listOverdue_showsAllOverdue() throws Exception {
         // prepare expectations
         TestDataHelper helper = new TestDataHelper();
-        Item task1 = helper.aDeadLine();
-        task1.setEndDate(LocalDateTime.of(2015, 9, 9, 9, 9));
+        Item target = helper.aDeadLine();
+        target.setEndDate(LocalDateTime.of(2015, 9, 9, 9, 9));
         Item event = helper.aLongEvent();
         event.setEndDate(LocalDateTime.of(2015,10,10,9,9));
-        Item task2 = helper.aFloatingTask();
-        task2.setEndDate(LocalDateTime.of(2020,10,10,10,10));
-        List<Item> allItems = helper.generateItemList(event, task1, task2);
-        List<Item> expectedList = helper.generateItemList(task1);
+        Item notDue = helper.aFloatingTask();
+        notDue.setEndDate(LocalDateTime.of(2020,10,10,10,10));
+        List<Item> allItems = helper.generateItemList(event, target, notDue);
+        List<Item> expectedList = helper.generateItemList(target);
         TaskBook expectedTB = helper.generateTaskBook(allItems);
 
         // prepare task book state

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -298,7 +298,6 @@ public class LogicManagerTest<E> {
         TaskBook expectedTB = helper.generateTaskBook(allItems);
 
         // prepare task book state
-        helper.addToModel(model, 2);
         assertCommandBehavior("list task", (String.format(ListCommand.MESSAGE_SUCCESS,"TASK")), expectedTB, expectedList);
     }
 
@@ -312,7 +311,7 @@ public class LogicManagerTest<E> {
 
         // prepare task book state
         helper.addToModel(model, 2);
-        assertCommandBehavior("list", (String.format(ListCommand.MESSAGE_SUCCESS,"")), expectedAB, expectedList);
+        assertCommandBehavior("list", (String.format(ListCommand.MESSAGE_SUCCESS,"ITEM")), expectedAB, expectedList);
     }
 
     @Test
@@ -338,7 +337,7 @@ public class LogicManagerTest<E> {
 
         // prepare task book state
         helper.addToModel(model, 2);
-        assertCommandBehavior("list", (String.format(ListCommand.MESSAGE_SUCCESS,"")), expectedAB, expectedList);
+        assertCommandBehavior("list", (String.format(ListCommand.MESSAGE_SUCCESS,"ITEM")), expectedAB, expectedList);
     }
     
     @Test
@@ -351,7 +350,7 @@ public class LogicManagerTest<E> {
 
         // prepare task book state
         helper.addToModel(model, 2);
-        assertCommandBehavior("list", (String.format(ListCommand.MESSAGE_SUCCESS,"")), expectedAB, expectedList);
+        assertCommandBehavior("list", (String.format(ListCommand.MESSAGE_SUCCESS,"ITEM")), expectedAB, expectedList);
     }
 
     @Test
@@ -672,11 +671,11 @@ public class LogicManagerTest<E> {
         Item p3 = helper.generateItemWithName("key key");
         Item p4 = helper.generateItemWithName("KEy sduauo");
         
-        String newDescription = "ba lion";
+        String newDescription = "walk the lion";
         Item modified = helper.generateItemWithName(newDescription);
 
         List<Item> fourItems = helper.generateItemList(p3, p1, p4, p2);
-        List<Item> expectedList = helper.generateItemList(modified, p3, p4, p2);
+        List<Item> expectedList = helper.generateItemList(p1, p4, p2, modified);
         TaskBook expectedTB = helper.generateTaskBook(expectedList);
         helper.addToModel(model, fourItems);
 

--- a/src/test/java/seedu/address/testutil/TestItem.java
+++ b/src/test/java/seedu/address/testutil/TestItem.java
@@ -2,15 +2,17 @@ package seedu.address.testutil;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Comparator;
 import java.util.Objects;
 import java.util.Observable;
 
 import seedu.address.logic.parser.DateTimeParser;
 import seedu.address.model.item.Description;
+import seedu.address.model.item.Item;
 import seedu.address.model.item.ReadOnlyItem;
 import seedu.address.model.tag.UniqueTagList;
 
-public class TestItem extends Observable implements ReadOnlyItem {
+public class TestItem extends Observable implements ReadOnlyItem, Comparable<TestItem>{
 
 
     private UniqueTagList tags;
@@ -190,4 +192,63 @@ public class TestItem extends Observable implements ReadOnlyItem {
 		}
 
 	}
+	
+    public static final Comparator<TestItem> chronologicalComparator = new Comparator<TestItem>(){
+        public int compare(TestItem x, TestItem y) {
+            return x.compareTo(y);
+        }
+    };
+
+    //@@author A0147609X-reused
+    @Override
+    /**
+     * sort by start date then end date then alphabetically
+     * for UI chronological sort
+     * @author darren
+     */
+    public int compareTo(TestItem other) {
+        LocalDateTime thisStart, thisEnd, otherStart, otherEnd;
+        
+        thisStart = assignDummyLDT(startDate);
+        thisEnd = assignDummyLDT(endDate);
+        otherStart = assignDummyLDT(other.getStartDate());
+        otherEnd = assignDummyLDT(other.getEndDate());
+        
+        if(thisStart.isBefore(otherStart)) {
+            // this item starts earlier
+            return -1;
+        } else if(thisStart.isAfter(otherStart)) {
+            // this item starts later
+            return 1;
+        } else {
+            // both have same start datetime
+            if(thisEnd.isBefore(otherEnd)) {
+                return -1;
+            } else if(thisEnd.isAfter(otherEnd)){
+                return 1;
+            }
+        }
+        
+        // same start and end date
+        // sort alphabetically by description
+        return description.compareTo(other.getDescription());
+    }
+    
+    /**
+     * assign the max LocalDateTime as a dummy to a java.time.LocalDateTime
+     * object if necessary
+     * @param checkee
+     * @return
+     * @author darren
+     */
+    private LocalDateTime assignDummyLDT(LocalDateTime checkee) {
+        if(checkee == null) {
+            return LocalDateTime.MAX;
+        }
+        
+        return checkee;
+    }
+    //@@author
+
+
 }

--- a/src/test/java/seedu/address/testutil/TestItem.java
+++ b/src/test/java/seedu/address/testutil/TestItem.java
@@ -8,7 +8,6 @@ import java.util.Observable;
 
 import seedu.address.logic.parser.DateTimeParser;
 import seedu.address.model.item.Description;
-import seedu.address.model.item.Item;
 import seedu.address.model.item.ReadOnlyItem;
 import seedu.address.model.tag.UniqueTagList;
 
@@ -194,7 +193,8 @@ public class TestItem extends Observable implements ReadOnlyItem, Comparable<Tes
 	}
 	
     public static final Comparator<TestItem> chronologicalComparator = new Comparator<TestItem>(){
-        public int compare(TestItem x, TestItem y) {
+        @Override
+		public int compare(TestItem x, TestItem y) {
             return x.compareTo(y);
         }
     };
@@ -207,7 +207,10 @@ public class TestItem extends Observable implements ReadOnlyItem, Comparable<Tes
      * @author darren
      */
     public int compareTo(TestItem other) {
-        LocalDateTime thisStart, thisEnd, otherStart, otherEnd;
+		LocalDateTime thisStart;
+		LocalDateTime thisEnd;
+		LocalDateTime otherStart;
+		LocalDateTime otherEnd;
         
         thisStart = assignDummyLDT(startDate);
         thisEnd = assignDummyLDT(endDate);

--- a/src/test/java/seedu/address/testutil/TestUtil.java
+++ b/src/test/java/seedu/address/testutil/TestUtil.java
@@ -29,6 +29,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
@@ -334,6 +335,7 @@ public class TestUtil {
     public static TestItem[] addItemsToList(final TestItem[] items, TestItem... itemsToAdd) {
         List<TestItem> listOfItems = asList(items);
         listOfItems.addAll(asList(itemsToAdd));
+        Collections.sort(listOfItems);
         return listOfItems.toArray(new TestItem[listOfItems.size()]);
     }
 

--- a/src/test/java/seedu/address/testutil/TypicalTestItems.java
+++ b/src/test/java/seedu/address/testutil/TypicalTestItems.java
@@ -1,5 +1,9 @@
 package seedu.address.testutil;
 
+import java.util.Arrays;
+
+import org.ocpsoft.prettytime.shade.edu.emory.mathcs.backport.java.util.Collections;
+
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.TaskBook;
 import seedu.address.model.item.Item;
@@ -50,7 +54,9 @@ public class TypicalTestItems {
 
     //@@author A0144750J
     public TestItem[] getTypicalItems() {
-        return new TestItem[]{always, bags, cs2103, dover, eating, frolick, grass};
+        TestItem[] answer = new TestItem[]{always, bags, cs2103, dover, eating, frolick, grass};
+        Arrays.sort(answer);
+        return answer;
     }
 
     //@@author A0144750J-reused

--- a/src/test/java/seedu/address/testutil/TypicalTestItems.java
+++ b/src/test/java/seedu/address/testutil/TypicalTestItems.java
@@ -2,8 +2,6 @@ package seedu.address.testutil;
 
 import java.util.Arrays;
 
-import org.ocpsoft.prettytime.shade.edu.emory.mathcs.backport.java.util.Collections;
-
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.TaskBook;
 import seedu.address.model.item.Item;


### PR DESCRIPTION
1. Allows the `find` command to search through metatags with #hashtag keywords. These commands do not change the context of the search; context switching is still done through `list`. e.g. `find #undone #task #cool` lists all items that have the metatags #undone and #task, as well as the user-generated tag #cool.
2. Tag now checks to disallow adding a tag with a metatag name to facilitate this.
5. In addition, all items are listed in chronological order, with the oldest item first on the list! Hooray! :) -- fixes #38 for real this time
6. Also fixes #72 because this is one multifunctional PR