### PR TITLE
Fixed ability to add weird dates

### DIFF
--- a/src/main/java/seedu/sudowudo/commons/util/ListUtil.java
+++ b/src/main/java/seedu/sudowudo/commons/util/ListUtil.java
@@ -25,7 +25,7 @@ public class ListUtil {
 
     }
     
-    public Predicate setDefaultPredicate(String taskType){
+    public Predicate setDefaultPredicate(Item.Type taskType){
         return new QualifierPredicate(new TypeQualifier(taskType));
     }
     
@@ -76,8 +76,8 @@ public class ListUtil {
     private class TypeQualifier implements Qualifier {
         private Item.Type type;
 
-        TypeQualifier(String type) {
-            this.type = Item.Type.valueOf(type);
+        TypeQualifier(Item.Type type) {
+            this.type = type;
         }
 
         @Override

--- a/src/main/java/seedu/sudowudo/commons/util/ListUtil.java
+++ b/src/main/java/seedu/sudowudo/commons/util/ListUtil.java
@@ -174,7 +174,7 @@ public class ListUtil {
         private boolean matchesTags(ReadOnlyItem item) {
             keyword = keyword.replaceFirst(Parser.COMMAND_TAG_PREFIX, "");
             if (isKeywordType()){
-                return item.is(Item.Type.valueOf(keyword));
+                return item.is(Item.Type.fromString(keyword));
             }
 
             return StringUtil.containsIgnoreCase(item.getTags().listTags(),keyword);

--- a/src/main/java/seedu/sudowudo/commons/util/ListUtil.java
+++ b/src/main/java/seedu/sudowudo/commons/util/ListUtil.java
@@ -74,10 +74,10 @@ public class ListUtil {
      *
      */
     private class TypeQualifier implements Qualifier {
-        private String type;
+        private Item.Type type;
 
         TypeQualifier(String type) {
-            this.type = type;
+            this.type = Item.Type.valueOf(type);
         }
 
         @Override
@@ -174,7 +174,7 @@ public class ListUtil {
         private boolean matchesTags(ReadOnlyItem item) {
             keyword = keyword.replaceFirst(Parser.COMMAND_TAG_PREFIX, "");
             if (isKeywordType()){
-                return item.is(keyword);
+                return item.is(Item.Type.valueOf(keyword));
             }
 
             return StringUtil.containsIgnoreCase(item.getTags().listTags(),keyword);

--- a/src/main/java/seedu/sudowudo/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/sudowudo/logic/commands/AddCommand.java
@@ -30,7 +30,6 @@ public class AddCommand extends Command {
             + "\"Be awesome\" from 1300 to 2359 on 07/10/2016 #cool #nice";
 
     public static final String MESSAGE_SUCCESS = "New %1$s added: %2$s";
-    public static final String MESSAGE_SUCCESS_TIME_NULL = "START or END time not found but new %1$s added!";
     public static final String MESSAGE_DUPLICATE_ITEM = "This task already exists in the to-do list";
     public static final String MESSAGE_UNDO_SUCCESS = "Undo add task: %1$s";
     private static final String DEFAULT_ITEM_NAME = "BLOCK";

--- a/src/main/java/seedu/sudowudo/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/sudowudo/logic/commands/AddCommand.java
@@ -115,15 +115,9 @@ public class AddCommand extends Command {
             // if user input something for time but it's not correct format
             hasUndo = true;
             toUndoAdd = toAdd;
-            if (this.hasTimeString && (this.toAdd.getStartDate() == null
-                    && this.toAdd.getEndDate() == null)) {
-                return new CommandResult(String.format(
-                        MESSAGE_SUCCESS_TIME_NULL, toAdd.getType()), toAdd);
-            } else {
-                return new CommandResult(
-                        String.format(MESSAGE_SUCCESS, toAdd.getType(), toAdd),
-                        toAdd);
-            }
+            return new CommandResult(
+                    String.format(MESSAGE_SUCCESS, toAdd.getType(), toAdd),
+                    toAdd);
         } catch (UniqueItemList.DuplicateItemException e) {
             hasUndo = false;
             return new CommandResult(MESSAGE_DUPLICATE_ITEM);

--- a/src/main/java/seedu/sudowudo/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/sudowudo/logic/commands/ListCommand.java
@@ -1,5 +1,7 @@
 package seedu.sudowudo.logic.commands;
 
+import seedu.sudowudo.model.item.Item;
+
 /**
  * Lists all items in the task book to the user.
  */
@@ -16,58 +18,18 @@ public class ListCommand extends Command {
 			+ "Parameter: \"OPTIONAL_TYPE_ARGUMENT (task, event, done, overdue, undone)\""
             + "Example: list task";
 
-    //@@author A0131560U
-    private enum Type{
-        TASK("task", "tasks"),
-        EVENT("event", "events"), 
-        DONE("done", "completed tasks"), 
-        ITEM("item", "items"), 
-        OVERDUE("overdue", "overdue tasks"), 
-		UNDONE("undone", "incomplete tasks");
-        
-        private String typeName;
-        private String typeMessage;
 
-        Type(String name, String message) {
-            this.typeName = name;
-            this.typeMessage = message;
-        }
-        
-        static Type fromString(String input) {
-            for (Type type : values() ){
-                if (type.typeName.equals(input)){
-                    return type;
-                }
-            }
-            return null;
-        }
-
-
-        public String getTypeName() {
-            return this.typeName;
-        }
-
-        public Object getTypeMessage() {
-            return this.typeMessage;
-        }
-
-		@Override
-		public String toString() {
-			return this.typeMessage;
-		}
-    }
-
-    private Type itemType;
+    private Item.Type itemType;
     
     //@@author 
     public ListCommand(String argument) {
-        this.itemType = Type.fromString(argument);
+        this.itemType = Item.Type.fromString(argument);
     }
 
     @Override
     //@@author A0131560U
     public CommandResult execute() {
-       model.updateDefaultPredicate(itemType.getTypeName());
+       model.updateDefaultPredicate(itemType);
     	hasUndo = false;
 		return new CommandResult(String.format(MESSAGE_SUCCESS, itemType));
     }

--- a/src/main/java/seedu/sudowudo/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/sudowudo/logic/commands/ListCommand.java
@@ -31,7 +31,7 @@ public class ListCommand extends Command {
     public CommandResult execute() {
        model.updateDefaultPredicate(itemType);
     	hasUndo = false;
-		return new CommandResult(String.format(MESSAGE_SUCCESS, itemType));
+		return new CommandResult(String.format(MESSAGE_SUCCESS, itemType.getMessage()));
     }
 
     @Override

--- a/src/main/java/seedu/sudowudo/logic/parser/Parser.java
+++ b/src/main/java/seedu/sudowudo/logic/parser/Parser.java
@@ -173,7 +173,7 @@ public class Parser {
     private Command prepareList(String argument) {
         assert argument != null;
         if (argument.isEmpty()) {
-            return new ListCommand(Item.Type.ITEM.getTypeName());
+            return new ListCommand(Item.Type.ITEM.toString());
         } else if (isValidType(argument)) {
             return new ListCommand(argument.trim().toLowerCase());
         } else {

--- a/src/main/java/seedu/sudowudo/model/Model.java
+++ b/src/main/java/seedu/sudowudo/model/Model.java
@@ -83,6 +83,7 @@ public interface Model {
     void updateFilteredItemList(Set<String> keywords);
 
     /** Updates the default filter of the item list to filter by a specific task type limiter */
-    void updateDefaultPredicate(String taskType);
+    void updateDefaultPredicate(Item.Type taskType);
+
 
 }

--- a/src/main/java/seedu/sudowudo/model/Model.java
+++ b/src/main/java/seedu/sudowudo/model/Model.java
@@ -5,6 +5,7 @@ import java.util.Set;
 
 import javafx.collections.transformation.FilteredList;
 import seedu.sudowudo.commons.core.UnmodifiableObservableList;
+import seedu.sudowudo.commons.exceptions.IllegalValueException;
 import seedu.sudowudo.logic.commands.Command;
 import seedu.sudowudo.model.item.Item;
 import seedu.sudowudo.model.item.ReadOnlyItem;
@@ -27,13 +28,16 @@ public interface Model {
     void addItem(Item item) throws UniqueItemList.DuplicateItemException;
     
     /** Edit the given Item's description */
-    void setItemDesc(Item item, String desc);
+    void setItemDesc(Item item, String desc) throws IllegalValueException;
     
     /** Edit the given Item's start datetime */
-    void setItemStart(Item item, LocalDateTime start);
+    void setItemStart(Item item, LocalDateTime start) throws IllegalValueException;
     
     /** Edit the given Item's end datetime */
-    void setItemEnd(Item item, LocalDateTime end);
+    void setItemEnd(Item item, LocalDateTime end) throws IllegalValueException;
+    
+    /** Edit the given Item's start and end datetime */
+    void setPeriod(Item item, LocalDateTime start, LocalDateTime end) throws IllegalValueException;
     
     // @@author A0144750J
     /** Set the item isDone field to true */

--- a/src/main/java/seedu/sudowudo/model/ModelManager.java
+++ b/src/main/java/seedu/sudowudo/model/ModelManager.java
@@ -2,7 +2,6 @@ package seedu.sudowudo.model;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.EmptyStackException;
 import java.util.Set;
 import java.util.Stack;
@@ -18,10 +17,7 @@ import seedu.sudowudo.commons.core.UnmodifiableObservableList;
 import seedu.sudowudo.commons.events.model.TaskBookChangedEvent;
 import seedu.sudowudo.commons.exceptions.IllegalValueException;
 import seedu.sudowudo.commons.util.ListUtil;
-import seedu.sudowudo.commons.util.StringUtil;
 import seedu.sudowudo.logic.commands.Command;
-import seedu.sudowudo.logic.parser.DateTimeParser;
-import seedu.sudowudo.logic.parser.Parser;
 import seedu.sudowudo.model.item.Item;
 import seedu.sudowudo.model.item.ReadOnlyItem;
 import seedu.sudowudo.model.item.UniqueItemList;
@@ -213,19 +209,6 @@ public class ModelManager extends ComponentManager implements Model {
     public void updateFilteredItemList(Set<String> keywords) {
     	ListUtil.getInstance().updateFilteredItemList(filteredItems, keywords, defaultPredicate);
     }
-
-	/*
-	 * @@author A0092390E
-	 * 
-	 */
-    private void updateFilteredItemList(Predicate pred) {
-        // Not used, to narrow searches the user has to type the entire search string in
-        // if(filteredItems.getPredicate() != null){
-        // filteredItems.setPredicate(pred.and(filteredItems.getPredicate()));
-        // } else{
-        filteredItems.setPredicate(pred);
-        // }
-    }
     
     //@@author A0144750J
     @Override
@@ -262,61 +245,5 @@ public class ModelManager extends ComponentManager implements Model {
         return commandHistory.size();
     }
     //@@author
-    
-    // ========== Inner classes/interfaces used for filtering ==================================================
-
-    private class QualifierPredicate implements Predicate<ReadOnlyItem> {
-
-        private final Qualifier qualifier;
-
-        QualifierPredicate(Qualifier qualifier) {
-            this.qualifier = qualifier;
-        }
-
-        @Override
-        public String toString() {
-            return qualifier.toString();
-        }
-
-        @Override
-        public boolean test(ReadOnlyItem item) {
-            return qualifier.run(item);
-        }
-
-    }
-
-    interface Qualifier {
-        boolean run(ReadOnlyItem item);
-
-        @Override
-        String toString();
-    }
-
-    //@@author A0131560U
-    /**
-     * A Qualifier class that particularly checks for Item Type (e.g. Task, Event, Done).
-     * @author craa
-     *
-     */
-    private class TypeQualifier implements Qualifier {
-        private String type;
-
-        TypeQualifier(String type) {
-            this.type = type;
-        }
-
-        @Override
-        public boolean run(ReadOnlyItem item) {
-            if (!item.is(type)) {
-                return false;
-            }
-            return true;
-        }
-
-        @Override
-        public String toString() {
-            return "type= " + type;
-        }
-
-    }
 }
+    

--- a/src/main/java/seedu/sudowudo/model/ModelManager.java
+++ b/src/main/java/seedu/sudowudo/model/ModelManager.java
@@ -103,19 +103,16 @@ public class ModelManager extends ComponentManager implements Model {
 
     //@@author A0147609X
     @Override
-	public void setItemDesc(Item item, String desc) {
-        try {
-            item.setDescription(desc);
-            updateFilteredListToShowAll();
-            indicateTaskBookChanged();
-        } catch (IllegalValueException ive) {
-        }
+	public void setItemDesc(Item item, String desc) throws IllegalValueException {
+        item.setDescription(desc);
+        updateFilteredListToShowAll();
+        indicateTaskBookChanged();
     }
     //@@author
     
     //@@author A0147609X
     @Override
-	public void setItemStart(Item item, LocalDateTime startDate) {
+	public void setItemStart(Item item, LocalDateTime startDate) throws IllegalValueException {
         item.setStartDate(startDate);
         updateFilteredListToShowAll();
         indicateTaskBookChanged();
@@ -124,12 +121,20 @@ public class ModelManager extends ComponentManager implements Model {
 
     //@@author A0147609X
     @Override
-	public void setItemEnd(Item item, LocalDateTime endDate) {
+	public void setItemEnd(Item item, LocalDateTime endDate) throws IllegalValueException {
         item.setEndDate(endDate);
         updateFilteredListToShowAll();
         indicateTaskBookChanged();
     }
     //@@author
+    
+    //@@author A0131560U
+    @Override
+    public void setPeriod(Item item, LocalDateTime startDate, LocalDateTime endDate) throws IllegalValueException {
+        item.setPeriod(startDate, endDate);
+        updateFilteredListToShowAll();
+        indicateTaskBookChanged();
+    }
     
     // @@author A0144750J
     @Override

--- a/src/main/java/seedu/sudowudo/model/ModelManager.java
+++ b/src/main/java/seedu/sudowudo/model/ModelManager.java
@@ -52,12 +52,12 @@ public class ModelManager extends ComponentManager implements Model {
         filteredItems = new FilteredList<>(taskBook.getItems());
         commandStack = new Stack<>();
         commandHistory = new ArrayList<String>();
-        this.defaultPredicate = ListUtil.getInstance().setDefaultPredicate("item");
+        this.defaultPredicate = ListUtil.getInstance().setDefaultPredicate(Item.Type.ITEM);
     }
 
     public ModelManager() {
         this(new TaskBook(), new UserPrefs());
-        this.defaultPredicate = ListUtil.getInstance().setDefaultPredicate("item");
+        this.defaultPredicate = ListUtil.getInstance().setDefaultPredicate(Item.Type.ITEM);
     }
 
     public ModelManager(ReadOnlyTaskBook initialData, UserPrefs userPrefs) {
@@ -65,7 +65,7 @@ public class ModelManager extends ComponentManager implements Model {
         filteredItems = new FilteredList<>(taskBook.getItems());
         commandStack = new Stack<>();
         commandHistory = new ArrayList<String>();
-        this.defaultPredicate = ListUtil.getInstance().setDefaultPredicate("item");
+        this.defaultPredicate = ListUtil.getInstance().setDefaultPredicate(Item.Type.ITEM);
     }
 
     @Override
@@ -200,7 +200,7 @@ public class ModelManager extends ComponentManager implements Model {
 
     @Override
     //@@author A0131560U
-    public void updateDefaultPredicate(String taskType) {
+    public void updateDefaultPredicate(Item.Type taskType) {
         defaultPredicate = ListUtil.getInstance().setDefaultPredicate(taskType);
         filteredItems.setPredicate(defaultPredicate);
     }

--- a/src/main/java/seedu/sudowudo/model/item/Item.java
+++ b/src/main/java/seedu/sudowudo/model/item/Item.java
@@ -12,16 +12,16 @@ import seedu.sudowudo.logic.parser.DateTimeParser;
 import seedu.sudowudo.model.tag.UniqueTagList;
 
 /**
- * Represents a Item in the task book. Guarantees: details are present and
- * not null, field values are validated.
+ * Represents a Item in the task book. Guarantees: details are present and not
+ * null, field values are validated.
  * 
  */
 public class Item extends Observable implements ReadOnlyItem, Comparable<Item> {
-    
-    //@@author A0131560U
+
+    // @@author A0131560U
     public enum Type {
         TASK("task"), EVENT("event"), DONE("done"), ITEM("item"), OVERDUE("overdue"), UNDONE("undone");
-        
+
         private String typeName;
 
         Type(String name) {
@@ -32,12 +32,10 @@ public class Item extends Observable implements ReadOnlyItem, Comparable<Item> {
             return this.typeName;
         }
     }
-    //@@author
-
+    // @@author
 
     public static final String MESSAGE_DATE_CONSTRAINTS = "Start date must come before end date.";
 
-    
     private UniqueTagList tags;
     private Description description;
     private boolean isDone;
@@ -60,67 +58,73 @@ public class Item extends Observable implements ReadOnlyItem, Comparable<Item> {
         this.tags = new UniqueTagList(tags);
     }
 
-    //@@author A0147609X
+    // @@author A0147609X
     /**
-     * constructor for an item with a definite
-     * start and end time (non-recurring)
+     * constructor for an item with a definite start and end time
+     * (non-recurring)
+     * 
      * @param desc
      * @param start
      * @param end
      * @author darren
      */
-    public Item(Description desc, LocalDateTime start, LocalDateTime end, UniqueTagList tags) throws IllegalValueException {
+    public Item(Description desc, LocalDateTime start, LocalDateTime end, UniqueTagList tags)
+            throws IllegalValueException {
         assert !CollectionUtil.isAnyNull(desc);
         this.description = desc;
-        if (!isValidInterval(start, end)){
+        if (!isValidInterval(start, end)) {
             throw new IllegalValueException(MESSAGE_DATE_CONSTRAINTS);
         }
         this.startDate = start;
         this.endDate = end;
         this.tags = new UniqueTagList(tags);
     }
-    //@@author
+    // @@author
 
     /**
-	 * constructor for an item with a definite end time only (non-recurring)
-	 * 
-	 * @param desc
-	 * @param end
-	 * @author darren
-	 */
+     * constructor for an item with a definite end time only (non-recurring)
+     * 
+     * @param desc
+     * @param end
+     * @author darren
+     */
     public Item(Description desc, LocalDateTime end, UniqueTagList tags) {
         assert !CollectionUtil.isAnyNull(desc);
         this.description = desc;
         this.endDate = end;
         this.tags = new UniqueTagList(tags);
     }
-    
+
     /**
-	 * constructor for an item with all fields: description, start/end date, tags and isDone
-	 * 
-	 * @param desc
-	 * @param end
-	 * @@author A0144750J
-	 */
+     * constructor for an item with all fields: description, start/end date,
+     * tags and isDone
+     * 
+     * @param desc
+     * @param end
+     * @@author A0144750J
+     */
     public Item(Description desc, LocalDateTime start, LocalDateTime end, UniqueTagList tags, boolean isDone) {
         assert !CollectionUtil.isAnyNull(desc);
         this.description = desc;
-		this.startDate = start;
+        this.startDate = start;
         this.endDate = end;
         this.tags = new UniqueTagList(tags);
         this.setIsDone(isDone);
     }
-    
+
     /**
      * Copy constructor to build an Item from a ReadOnlyItem
-     * @param source: ReadOnlyItem that can return Description, startDate, endDate and isDone;
+     * 
+     * @param source:
+     *            ReadOnlyItem that can return Description, startDate, endDate
+     *            and isDone;
      * @@author A0144750J
      */
     public Item(ReadOnlyItem source) {
         this(source.getDescription(), source.getStartDate(), source.getEndDate(), source.getTags(), source.getIsDone());
     }
 
-	/* @@author A0092390E */
+    /* @@author A0092390E */
 
     @Override
     public UniqueTagList getTags() {
@@ -128,22 +132,22 @@ public class Item extends Observable implements ReadOnlyItem, Comparable<Item> {
     }
 
     @Override
-	public Description getDescription() {
+    public Description getDescription() {
         return description;
     }
 
     @Override
-	public boolean getIsDone() {
+    public boolean getIsDone() {
         return isDone;
     }
 
     @Override
-	public LocalDateTime getStartDate() {
+    public LocalDateTime getStartDate() {
         return startDate;
     }
 
     @Override
-	public LocalDateTime getEndDate() {
+    public LocalDateTime getEndDate() {
         return endDate;
     }
 
@@ -155,92 +159,91 @@ public class Item extends Observable implements ReadOnlyItem, Comparable<Item> {
         return recurInterval;
 
     }
+
     public LocalDateTime getRecurEndDate() {
         return recurEndDate;
     }
-    
-	/**
-	 * Flexible property querying, to support listing and filtering
-	 * 
-	 * @return boolean, whether the item is or isn't
-	 * @@author A0092390E
-	 */
+
+    /**
+     * Flexible property querying, to support listing and filtering
+     * 
+     * @return boolean, whether the item is or isn't
+     * @@author A0092390E
+     */
     @Override
-	public boolean is(String query){
-		switch (query.toLowerCase()) {
-		case "done":
-			return this.getIsDone();
-		case "undone":
-		    return !this.getIsDone();
-		case "event":
-			return this.getStartDate() != null;
-		case "task":
-			return this.getStartDate() == null;
-		case "overdue":
-			return this.is("task") && this.getEndDate() != null 
-			        && this.getEndDate().isBefore(LocalDateTime.now());
-		case "item":
-		    return true;
-		default:
-			return false;
-		}
+    public boolean is(String query) {
+        switch (query.toLowerCase()) {
+        case "done":
+            return this.getIsDone();
+        case "undone":
+            return !this.getIsDone();
+        case "event":
+            return this.getStartDate() != null;
+        case "task":
+            return this.getStartDate() == null;
+        case "overdue":
+            return this.is("task") && this.getEndDate() != null && this.getEndDate().isBefore(LocalDateTime.now());
+        case "item":
+            return true;
+        default:
+            return false;
+        }
     }
 
-	/**
-	 * Returns the type of the item. Useful for Item cards and messages.
-	 * 
-	 * @return The type of the item, computed based on start/end dates.
-	 *         [Event|Floating Task|Task]
-	 * @@author A0092390E
-	 */
-	@Override
-	public String getType() {
-		if (this.getStartDate() != null) {
-			return "Event";
-		} else if (this.getEndDate() == null) {
-			return "Floating Task";
-		} else {
-			return "Task";
-		}
-	}
+    /**
+     * Returns the type of the item. Useful for Item cards and messages.
+     * 
+     * @return The type of the item, computed based on start/end dates.
+     *         [Event|Floating Task|Task]
+     * @@author A0092390E
+     */
+    @Override
+    public String getType() {
+        if (this.getStartDate() != null) {
+            return "Event";
+        } else if (this.getEndDate() == null) {
+            return "Floating Task";
+        } else {
+            return "Task";
+        }
+    }
 
-	/**
-	 * Replaces this Item's tags with the tags in the argument tag list.
-	 */
+    /**
+     * Replaces this Item's tags with the tags in the argument tag list.
+     */
     public void setTags(UniqueTagList replacement) {
         tags.setTags(replacement);
-		setChanged();
-		notifyObservers();
+        setChanged();
+        notifyObservers();
     }
 
-    
     @Override
-	public void setIsDone(boolean doneness) {
+    public void setIsDone(boolean doneness) {
         this.isDone = doneness;
-		setChanged();
-		notifyObservers();
+        setChanged();
+        notifyObservers();
     }
 
     public void setStartDate(LocalDateTime startDate) throws IllegalValueException {
-        if (!isValidInterval(startDate, this.endDate)){
+        if (!isValidInterval(startDate, this.endDate)) {
             throw new IllegalValueException(MESSAGE_DATE_CONSTRAINTS);
         }
         this.startDate = startDate;
-		setChanged();
-		notifyObservers();
+        setChanged();
+        notifyObservers();
     }
 
-    public void setEndDate(LocalDateTime endDate) throws IllegalValueException {        
-        if (!isValidInterval(this.startDate, endDate)){
+    public void setEndDate(LocalDateTime endDate) throws IllegalValueException {
+        if (!isValidInterval(this.startDate, endDate)) {
             throw new IllegalValueException(MESSAGE_DATE_CONSTRAINTS);
         }
         this.endDate = endDate;
-		setChanged();
-		notifyObservers();
+        setChanged();
+        notifyObservers();
     }
-    
+
     public void setPeriod(LocalDateTime startDate, LocalDateTime endDate) throws IllegalValueException {
-        if (!isValidInterval(startDate, endDate)){
+        if (!isValidInterval(startDate, endDate)) {
             throw new IllegalValueException(MESSAGE_DATE_CONSTRAINTS);
         }
         this.startDate = startDate;
@@ -253,11 +256,12 @@ public class Item extends Observable implements ReadOnlyItem, Comparable<Item> {
         return start == null || end == null || start.isBefore(end);
     }
 
-	public void setDescription(String desc) throws IllegalValueException {
-		this.description.setFullDescription(desc);
-		setChanged();
-		notifyObservers();
-	}
+    public void setDescription(String desc) throws IllegalValueException {
+        this.description.setFullDescription(desc);
+        setChanged();
+        notifyObservers();
+    }
+
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing
@@ -270,15 +274,14 @@ public class Item extends Observable implements ReadOnlyItem, Comparable<Item> {
         return description.toString();
     }
 
-
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof ReadOnlyItem // instanceof handles nulls
-                && this.isSameStateAs((ReadOnlyItem) other));
+                        && this.isSameStateAs((ReadOnlyItem) other));
     }
 
-    //@@author A0147609X
+    // @@author A0147609X
     @Override
     /**
      * sort by start date then end date then alphabetically
@@ -286,24 +289,27 @@ public class Item extends Observable implements ReadOnlyItem, Comparable<Item> {
      * @author darren
      */
     public int compareTo(Item other) {
-        LocalDateTime thisStart = assignDummyLDT(startDate);
-        LocalDateTime thisEnd = assignDummyLDT(endDate);
+        LocalDateTime thisStart = assignDummyLDT(this.startDate);
+        LocalDateTime thisEnd = assignDummyLDT(this.endDate);
         LocalDateTime otherStart = assignDummyLDT(other.getStartDate());
         LocalDateTime otherEnd = assignDummyLDT(other.getEndDate());
         
-        if(thisStart.isBefore(otherStart)) {
+        // Assign same start/end date to a deadline for easier checking
+        if (this.is(Type.TASK.toString())){
+            thisStart = thisEnd;
+        }
+
+        if(thisEnd.isBefore(otherEnd)) {
+        // this item ends earlier
+            return -1;
+        } else if(thisEnd.isAfter(otherEnd)){
+            return 1;
+        } else if(thisStart.isBefore(otherStart)) {
             // this item starts earlier
             return -1;
         } else if(thisStart.isAfter(otherStart)) {
             // this item starts later
             return 1;
-        } else {
-            // both have same start datetime
-            if(thisEnd.isBefore(otherEnd)) {
-                return -1;
-            } else if(thisEnd.isAfter(otherEnd)){
-                return 1;
-            }
         }
         
         // same start and end date
@@ -314,20 +320,21 @@ public class Item extends Observable implements ReadOnlyItem, Comparable<Item> {
     /**
      * assign the max LocalDateTime as a dummy to a java.time.LocalDateTime
      * object if necessary
+     * 
      * @param checkee
      * @return
      * @author darren
      */
     private LocalDateTime assignDummyLDT(LocalDateTime checkee) {
-        if(checkee == null) {
+        if (checkee == null) {
             return LocalDateTime.MAX;
         }
-        
+
         return checkee;
     }
-    //@@author
-    
-    //@@author A0144750J
+    // @@author
+
+    // @@author A0144750J
     /**
      * Returns a deep copy of the current Item
      * 
@@ -336,42 +343,42 @@ public class Item extends Observable implements ReadOnlyItem, Comparable<Item> {
      */
     public Item deepCopy() {
         Item duplicate;
-        
+
         // copy each field to new item
         try {
-            duplicate = new Item(new Description("dummy"), null, null,
-                    new UniqueTagList());
-            duplicate.setDescription(
-                    this.getDescription().getFullDescription());
-	        duplicate.setStartDate(this.getStartDate());
-	        duplicate.setEndDate(this.getEndDate());
-	        duplicate.setIsDone(this.getIsDone());
-	        duplicate.setTags(this.getTags());
-	        return duplicate;
+            duplicate = new Item(new Description("dummy"), null, null, new UniqueTagList());
+            duplicate.setDescription(this.getDescription().getFullDescription());
+            duplicate.setStartDate(this.getStartDate());
+            duplicate.setEndDate(this.getEndDate());
+            duplicate.setIsDone(this.getIsDone());
+            duplicate.setTags(this.getTags());
+            return duplicate;
         } catch (IllegalValueException e) {
             e.printStackTrace();
         }
 
         return null;
-	}
-    //@@author
+    }
+    // @@author
 
-    //@@author A0147609X
-     /**
+    // @@author A0147609X
+    /**
      * Builds a pretty datetime line for this Item's card on the UI.
      * 
      * Nulls are handled by DateTimeParser.extractPrettyItemCardDateTime
+     * 
      * @return
      * @author darren
      */
     @Override
-	public String extractPrettyItemCardDateTime() {
+    public String extractPrettyItemCardDateTime() {
         return DateTimeParser.extractPrettyItemCardDateTime(this.startDate, this.endDate);
     }
-    
+
     /**
-     * Gets the pretty explicit datetime for this Item's start datetime
-     * e.g. "This Monday, 7:30PM" or "Mon 27 Nov, 9:30AM"
+     * Gets the pretty explicit datetime for this Item's start datetime e.g.
+     * "This Monday, 7:30PM" or "Mon 27 Nov, 9:30AM"
+     * 
      * @return
      * @author darren
      */
@@ -380,18 +387,20 @@ public class Item extends Observable implements ReadOnlyItem, Comparable<Item> {
     }
 
     /**
-     * Gets the pretty explicit datetime for this Item's end datetime
-     * e.g. "This Monday, 7:30PM" or "Mon 27 Nov, 9:30AM"
+     * Gets the pretty explicit datetime for this Item's end datetime e.g. "This
+     * Monday, 7:30PM" or "Mon 27 Nov, 9:30AM"
+     * 
      * @return
      * @author darren
      */
     public String extractPrettyEndDateTime() {
         return DateTimeParser.extractPrettyDateTime(this.endDate);
     }
-    
+
     /**
-     * Gets the pretty relative datetime for this Item's start datetime
-     * e.g. "3 weeks from now"
+     * Gets the pretty relative datetime for this Item's start datetime e.g. "3
+     * weeks from now"
+     * 
      * @return EMPTY_STRING if datetime is null
      * @author darren
      */
@@ -400,21 +409,22 @@ public class Item extends Observable implements ReadOnlyItem, Comparable<Item> {
     }
 
     /**
-     * Gets the pretty relative datetime for this Item's end datetime
-     * e.g. "3 weeks from now"
+     * Gets the pretty relative datetime for this Item's end datetime e.g. "3
+     * weeks from now"
+     * 
      * @return EMPTY_STRING if datetime is null
      * @author darren
      */
     @Override
-	public String extractPrettyRelativeEndDateTime() {
-        if(this.endDate == null) {
+    public String extractPrettyRelativeEndDateTime() {
+        if (this.endDate == null) {
             return extractPrettyRelativeStartDateTime();
         }
         return DateTimeParser.extractPrettyRelativeDateTime(this.endDate);
     }
-    //@@author
-    
-    public static final Comparator<Item> chronologicalComparator = new Comparator<Item>(){
+    // @@author
+
+    public static final Comparator<Item> chronologicalComparator = new Comparator<Item>() {
         @Override
         public int compare(Item x, Item y) {
             return x.compareTo(y);

--- a/src/main/java/seedu/sudowudo/model/item/Item.java
+++ b/src/main/java/seedu/sudowudo/model/item/Item.java
@@ -34,6 +34,9 @@ public class Item extends Observable implements ReadOnlyItem, Comparable<Item> {
     }
     //@@author
 
+
+    private static final String MESSAGE_DATE_CONSTRAINTS = "Start date must come before end date.";
+
     
     private UniqueTagList tags;
     private Description description;
@@ -66,16 +69,19 @@ public class Item extends Observable implements ReadOnlyItem, Comparable<Item> {
      * @param end
      * @author darren
      */
-    public Item(Description desc, LocalDateTime start, LocalDateTime end, UniqueTagList tags) {
+    public Item(Description desc, LocalDateTime start, LocalDateTime end, UniqueTagList tags) throws IllegalValueException {
         assert !CollectionUtil.isAnyNull(desc);
         this.description = desc;
+        if (!isIntervalValid(start, end)){
+            throw new IllegalValueException(MESSAGE_DATE_CONSTRAINTS);
+        }
         this.startDate = start;
         this.endDate = end;
         this.tags = new UniqueTagList(tags);
     }
     //@@author
-    
-	/**
+
+    /**
 	 * constructor for an item with a definite end time only (non-recurring)
 	 * 
 	 * @param desc
@@ -216,16 +222,27 @@ public class Item extends Observable implements ReadOnlyItem, Comparable<Item> {
 		notifyObservers();
     }
 
-    public void setStartDate(LocalDateTime startDate) {
+    public void setStartDate(LocalDateTime startDate) throws IllegalValueException {
+        if (!isIntervalValid(this.startDate, endDate)){
+            throw new IllegalValueException(MESSAGE_DATE_CONSTRAINTS);
+        }
         this.startDate = startDate;
 		setChanged();
 		notifyObservers();
     }
 
-    public void setEndDate(LocalDateTime endDate) {
+    public void setEndDate(LocalDateTime endDate) throws IllegalValueException {
+        if (!isIntervalValid(this.startDate, endDate)){
+            throw new IllegalValueException(MESSAGE_DATE_CONSTRAINTS);
+        }
+        
         this.endDate = endDate;
 		setChanged();
 		notifyObservers();
+    }
+    
+    private boolean isIntervalValid(LocalDateTime start, LocalDateTime end) {
+        return start.isBefore(end);
     }
 
     public void setRecurring(boolean isRecurring) {

--- a/src/main/java/seedu/sudowudo/model/item/Item.java
+++ b/src/main/java/seedu/sudowudo/model/item/Item.java
@@ -43,7 +43,7 @@ public class Item extends Observable implements ReadOnlyItem, Comparable<Item> {
 
     private LocalDateTime startDate;
     private LocalDateTime endDate;
-
+    
     /**
      * constructor for floating item
      */
@@ -146,11 +146,6 @@ public class Item extends Observable implements ReadOnlyItem, Comparable<Item> {
     public LocalDateTime getEndDate() {
         return endDate;
     }
-
-    @Override
-    public boolean is(Type query){
-        return is(query.toString());
-    }
     
     /**
      * Flexible property querying, to support listing and filtering
@@ -158,19 +153,20 @@ public class Item extends Observable implements ReadOnlyItem, Comparable<Item> {
      * @return boolean, whether the item is or isn't
      * @@author A0092390E
      */
-    public boolean is(String query) {
-        switch (query.toLowerCase()) {
-        case "done":
+    @Override
+    public boolean is(Type query) {
+        switch (query) {
+        case DONE:
             return this.getIsDone();
-        case "undone":
+        case UNDONE:
             return !this.getIsDone();
-        case "event":
+        case EVENT:
             return this.getStartDate() != null;
-        case "task":
+        case TASK:
             return this.getStartDate() == null;
-        case "overdue":
-            return this.is("task") && this.getEndDate() != null && this.getEndDate().isBefore(LocalDateTime.now());
-        case "item":
+        case OVERDUE:
+            return this.is(Type.TASK) && this.getEndDate() != null && this.getEndDate().isBefore(LocalDateTime.now());
+        case ITEM:
             return true;
         default:
             return false;
@@ -204,7 +200,6 @@ public class Item extends Observable implements ReadOnlyItem, Comparable<Item> {
         notifyObservers();
     }
 
-    @Override
     public void setIsDone(boolean isDone) {
         this.isDone = isDone;
         setChanged();
@@ -283,10 +278,10 @@ public class Item extends Observable implements ReadOnlyItem, Comparable<Item> {
         LocalDateTime otherEnd = assignDummyLDT(other.getEndDate());
 
         // Assign same start/end date to a deadline for easier checking
-        if (this.is(Type.TASK.toString())) {
+        if (this.is(Type.TASK)) {
             thisStart = thisEnd;
         }
-        if (other.is(Type.TASK.toString())) {
+        if (other.is(Type.TASK)) {
             otherStart = otherEnd;
         }
 

--- a/src/main/java/seedu/sudowudo/model/item/Item.java
+++ b/src/main/java/seedu/sudowudo/model/item/Item.java
@@ -72,7 +72,7 @@ public class Item extends Observable implements ReadOnlyItem, Comparable<Item> {
     public Item(Description desc, LocalDateTime start, LocalDateTime end, UniqueTagList tags) throws IllegalValueException {
         assert !CollectionUtil.isAnyNull(desc);
         this.description = desc;
-        if (!isIntervalValid(start, end)){
+        if (!isValidInterval(start, end)){
             throw new IllegalValueException(MESSAGE_DATE_CONSTRAINTS);
         }
         this.startDate = start;
@@ -221,23 +221,35 @@ public class Item extends Observable implements ReadOnlyItem, Comparable<Item> {
 		notifyObservers();
     }
 
-    public void setStartDate(LocalDateTime startDate) {
+    public void setStartDate(LocalDateTime startDate) throws IllegalValueException {
+        if (!isValidInterval(startDate, this.endDate)){
+            throw new IllegalValueException(MESSAGE_DATE_CONSTRAINTS);
+        }
         this.startDate = startDate;
 		setChanged();
 		notifyObservers();
     }
 
-    public void setEndDate(LocalDateTime endDate) throws IllegalValueException {
-        if (!isIntervalValid(this.startDate, endDate)){
+    public void setEndDate(LocalDateTime endDate) throws IllegalValueException {        
+        if (!isValidInterval(this.startDate, endDate)){
             throw new IllegalValueException(MESSAGE_DATE_CONSTRAINTS);
         }
-        
         this.endDate = endDate;
 		setChanged();
 		notifyObservers();
     }
     
-    private boolean isIntervalValid(LocalDateTime start, LocalDateTime end) {
+    public void setPeriod(LocalDateTime startDate, LocalDateTime endDate) throws IllegalValueException {
+        if (!isValidInterval(startDate, endDate)){
+            throw new IllegalValueException(MESSAGE_DATE_CONSTRAINTS);
+        }
+        this.startDate = startDate;
+        this.endDate = endDate;
+        setChanged();
+        notifyObservers();
+    }
+
+    private boolean isValidInterval(LocalDateTime start, LocalDateTime end) {
         return start.isBefore(end);
     }
 
@@ -426,4 +438,5 @@ public class Item extends Observable implements ReadOnlyItem, Comparable<Item> {
             return x.compareTo(y);
         }
     };
+
 }

--- a/src/main/java/seedu/sudowudo/model/item/Item.java
+++ b/src/main/java/seedu/sudowudo/model/item/Item.java
@@ -28,7 +28,8 @@ public class Item extends Observable implements ReadOnlyItem, Comparable<Item> {
             this.typeName = name;
         }
 
-        public String getTypeName() {
+        @Override
+        public String toString() {
             return this.typeName;
         }
     }
@@ -146,13 +147,17 @@ public class Item extends Observable implements ReadOnlyItem, Comparable<Item> {
         return endDate;
     }
 
+    @Override
+    public boolean is(Type query){
+        return is(query.toString());
+    }
+    
     /**
      * Flexible property querying, to support listing and filtering
      * 
      * @return boolean, whether the item is or isn't
      * @@author A0092390E
      */
-    @Override
     public boolean is(String query) {
         switch (query.toLowerCase()) {
         case "done":
@@ -200,8 +205,8 @@ public class Item extends Observable implements ReadOnlyItem, Comparable<Item> {
     }
 
     @Override
-    public void setIsDone(boolean doneness) {
-        this.isDone = doneness;
+    public void setIsDone(boolean isDone) {
+        this.isDone = isDone;
         setChanged();
         notifyObservers();
     }
@@ -266,8 +271,9 @@ public class Item extends Observable implements ReadOnlyItem, Comparable<Item> {
     // @@author A0147609X
     @Override
     /**
-     * sort by start date then end date then alphabetically
-     * for UI chronological sort
+     * sort by start date then end date then alphabetically for UI chronological
+     * sort
+     * 
      * @author darren
      */
     public int compareTo(Item other) {
@@ -275,28 +281,28 @@ public class Item extends Observable implements ReadOnlyItem, Comparable<Item> {
         LocalDateTime thisEnd = assignDummyLDT(this.endDate);
         LocalDateTime otherStart = assignDummyLDT(other.getStartDate());
         LocalDateTime otherEnd = assignDummyLDT(other.getEndDate());
-        
+
         // Assign same start/end date to a deadline for easier checking
-        if (this.is(Type.TASK.toString())){
+        if (this.is(Type.TASK.toString())) {
             thisStart = thisEnd;
         }
-        if (other.is(Type.TASK.toString())){
+        if (other.is(Type.TASK.toString())) {
             otherStart = otherEnd;
         }
 
-        if(thisEnd.isBefore(otherEnd)) {
-        // this item ends earlier
+        if (thisEnd.isBefore(otherEnd)) {
+            // this item ends earlier
             return -1;
-        } else if(thisEnd.isAfter(otherEnd)){
+        } else if (thisEnd.isAfter(otherEnd)) {
             return 1;
-        } else if(thisStart.isBefore(otherStart)) {
+        } else if (thisStart.isBefore(otherStart)) {
             // this item starts earlier
             return -1;
-        } else if(thisStart.isAfter(otherStart)) {
+        } else if (thisStart.isAfter(otherStart)) {
             // this item starts later
             return 1;
         }
-        
+
         // same start and end date
         // sort alphabetically by description
         return description.compareTo(other.getDescription());

--- a/src/main/java/seedu/sudowudo/model/item/Item.java
+++ b/src/main/java/seedu/sudowudo/model/item/Item.java
@@ -253,24 +253,6 @@ public class Item extends Observable implements ReadOnlyItem, Comparable<Item> {
         return start == null || end == null || start.isBefore(end);
     }
 
-    public void setRecurring(boolean isRecurring) {
-        this.isRecurring = isRecurring;
-		setChanged();
-		notifyObservers();
-    }
-
-    public void setRecurInterval(Period recurInterval) {
-        this.recurInterval = recurInterval;
-		setChanged();
-		notifyObservers();
-    }
-
-    public void setRecurEndDate(LocalDateTime recurEndDate) {
-        this.recurEndDate = recurEndDate;
-		setChanged();
-		notifyObservers();
-	}
-
 	public void setDescription(String desc) throws IllegalValueException {
 		this.description.setFullDescription(desc);
 		setChanged();

--- a/src/main/java/seedu/sudowudo/model/item/Item.java
+++ b/src/main/java/seedu/sudowudo/model/item/Item.java
@@ -1,7 +1,6 @@
 package seedu.sudowudo.model.item;
 
 import java.time.LocalDateTime;
-import java.time.Period;
 import java.util.Comparator;
 import java.util.Objects;
 import java.util.Observable;
@@ -19,7 +18,7 @@ import seedu.sudowudo.model.tag.UniqueTagList;
 public class Item extends Observable implements ReadOnlyItem, Comparable<Item> {
 
     // @@author A0131560U
-    public enum Type {
+    public static enum Type {
         TASK("task"), EVENT("event"), DONE("done"), ITEM("item"), OVERDUE("overdue"), UNDONE("undone");
 
         private String typeName;
@@ -32,6 +31,16 @@ public class Item extends Observable implements ReadOnlyItem, Comparable<Item> {
         public String toString() {
             return this.typeName;
         }
+        
+        public static Type fromString(String input) {
+            for (Type type : values() ){
+                if (type.typeName.equals(input)){
+                    return type;
+                }
+            }
+            return null;
+        }
+
     }
     // @@author
 

--- a/src/main/java/seedu/sudowudo/model/item/Item.java
+++ b/src/main/java/seedu/sudowudo/model/item/Item.java
@@ -35,7 +35,7 @@ public class Item extends Observable implements ReadOnlyItem, Comparable<Item> {
     //@@author
 
 
-    private static final String MESSAGE_DATE_CONSTRAINTS = "Start date must come before end date.";
+    public static final String MESSAGE_DATE_CONSTRAINTS = "Start date must come before end date.";
 
     
     private UniqueTagList tags;
@@ -250,7 +250,7 @@ public class Item extends Observable implements ReadOnlyItem, Comparable<Item> {
     }
 
     private boolean isValidInterval(LocalDateTime start, LocalDateTime end) {
-        return start.isBefore(end);
+        return start == null || end == null || start.isBefore(end);
     }
 
     public void setRecurring(boolean isRecurring) {

--- a/src/main/java/seedu/sudowudo/model/item/Item.java
+++ b/src/main/java/seedu/sudowudo/model/item/Item.java
@@ -298,6 +298,9 @@ public class Item extends Observable implements ReadOnlyItem, Comparable<Item> {
         if (this.is(Type.TASK.toString())){
             thisStart = thisEnd;
         }
+        if (other.is(Type.TASK.toString())){
+            otherStart = otherEnd;
+        }
 
         if(thisEnd.isBefore(otherEnd)) {
         // this item ends earlier

--- a/src/main/java/seedu/sudowudo/model/item/Item.java
+++ b/src/main/java/seedu/sudowudo/model/item/Item.java
@@ -31,10 +31,10 @@ public class Item extends Observable implements ReadOnlyItem, Comparable<Item> {
         public String toString() {
             return this.typeName;
         }
-        
+
         public static Type fromString(String input) {
-            for (Type type : values() ){
-                if (type.typeName.equals(input)){
+            for (Type type : values()) {
+                if (type.typeName.equals(input)) {
                     return type;
                 }
             }
@@ -52,7 +52,7 @@ public class Item extends Observable implements ReadOnlyItem, Comparable<Item> {
 
     private LocalDateTime startDate;
     private LocalDateTime endDate;
-    
+
     /**
      * constructor for floating item
      */
@@ -155,7 +155,7 @@ public class Item extends Observable implements ReadOnlyItem, Comparable<Item> {
     public LocalDateTime getEndDate() {
         return endDate;
     }
-    
+
     /**
      * Flexible property querying, to support listing and filtering
      * 

--- a/src/main/java/seedu/sudowudo/model/item/Item.java
+++ b/src/main/java/seedu/sudowudo/model/item/Item.java
@@ -19,17 +19,24 @@ public class Item extends Observable implements ReadOnlyItem, Comparable<Item> {
 
     // @@author A0131560U
     public static enum Type {
-        TASK("task"), EVENT("event"), DONE("done"), ITEM("item"), OVERDUE("overdue"), UNDONE("undone");
+        TASK("task", "tasks"), EVENT("event", "events"), DONE("done", "completed tasks"),
+        ITEM("item", "items"), OVERDUE("overdue", "overdue tasks"), UNDONE("undone", "incomplete tasks");
 
         private String typeName;
+        private String message;
 
-        Type(String name) {
+        Type(String name, String message) {
             this.typeName = name;
+            this.message = message;
         }
 
         @Override
         public String toString() {
             return this.typeName;
+        }
+        
+        public String getMessage(){
+            return this.message;
         }
 
         public static Type fromString(String input) {

--- a/src/main/java/seedu/sudowudo/model/item/Item.java
+++ b/src/main/java/seedu/sudowudo/model/item/Item.java
@@ -167,8 +167,7 @@ public class Item extends Observable implements ReadOnlyItem, Comparable<Item> {
 	 */
     @Override
 	public boolean is(String query){
-    	query = query.toLowerCase();
-		switch (query) {
+		switch (query.toLowerCase()) {
 		case "done":
 			return this.getIsDone();
 		case "undone":
@@ -222,10 +221,7 @@ public class Item extends Observable implements ReadOnlyItem, Comparable<Item> {
 		notifyObservers();
     }
 
-    public void setStartDate(LocalDateTime startDate) throws IllegalValueException {
-        if (!isIntervalValid(this.startDate, endDate)){
-            throw new IllegalValueException(MESSAGE_DATE_CONSTRAINTS);
-        }
+    public void setStartDate(LocalDateTime startDate) {
         this.startDate = startDate;
 		setChanged();
 		notifyObservers();
@@ -296,12 +292,10 @@ public class Item extends Observable implements ReadOnlyItem, Comparable<Item> {
      * @author darren
      */
     public int compareTo(Item other) {
-        LocalDateTime thisStart, thisEnd, otherStart, otherEnd;
-        
-        thisStart = assignDummyLDT(startDate);
-        thisEnd = assignDummyLDT(endDate);
-        otherStart = assignDummyLDT(other.getStartDate());
-        otherEnd = assignDummyLDT(other.getEndDate());
+        LocalDateTime thisStart = assignDummyLDT(startDate);
+        LocalDateTime thisEnd = assignDummyLDT(endDate);
+        LocalDateTime otherStart = assignDummyLDT(other.getStartDate());
+        LocalDateTime otherEnd = assignDummyLDT(other.getEndDate());
         
         if(thisStart.isBefore(otherStart)) {
             // this item starts earlier

--- a/src/main/java/seedu/sudowudo/model/item/Item.java
+++ b/src/main/java/seedu/sudowudo/model/item/Item.java
@@ -43,11 +43,6 @@ public class Item extends Observable implements ReadOnlyItem, Comparable<Item> {
     private LocalDateTime startDate;
     private LocalDateTime endDate;
 
-    // for recurring events only
-    private boolean isRecurring;
-    private Period recurInterval;
-    private LocalDateTime recurEndDate;
-
     /**
      * constructor for floating item
      */
@@ -149,19 +144,6 @@ public class Item extends Observable implements ReadOnlyItem, Comparable<Item> {
     @Override
     public LocalDateTime getEndDate() {
         return endDate;
-    }
-
-    public boolean isRecurring() {
-        return isRecurring;
-    }
-
-    public Period getRecurInterval() {
-        return recurInterval;
-
-    }
-
-    public LocalDateTime getRecurEndDate() {
-        return recurEndDate;
     }
 
     /**

--- a/src/main/java/seedu/sudowudo/model/item/ReadOnlyItem.java
+++ b/src/main/java/seedu/sudowudo/model/item/ReadOnlyItem.java
@@ -16,9 +16,6 @@ public interface ReadOnlyItem {
 
 	boolean getIsDone();
 
-	// THIS IS TEMPORARY (@darren)
-	void setIsDone(boolean doneness);
-
 	/**
 	 * These return the start and end dates of the item (if they exist). If not,
 	 * then the default null is used. Override these in the implemented classes
@@ -35,7 +32,7 @@ public interface ReadOnlyItem {
     /**
      * Flexible property querying, to support listing and filtering
      * Returns boolean, whether the item does or doesn't match query*/
-    public boolean is(String query);
+    public boolean is(Item.Type query);
 
 	
 	/**

--- a/src/main/java/seedu/sudowudo/storage/XmlSerializableTaskBook.java
+++ b/src/main/java/seedu/sudowudo/storage/XmlSerializableTaskBook.java
@@ -1,17 +1,19 @@
 package seedu.sudowudo.storage;
 
+import seedu.sudowudo.commons.core.LogsCenter;
 import seedu.sudowudo.commons.exceptions.IllegalValueException;
 import seedu.sudowudo.model.tag.Tag;
-import seedu.sudowudo.model.tag.UniqueTagList;
 import seedu.sudowudo.model.ReadOnlyTaskBook;
 import seedu.sudowudo.model.item.ReadOnlyItem;
 import seedu.sudowudo.model.item.UniqueItemList;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
+
+
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 /**
@@ -24,6 +26,8 @@ public class XmlSerializableTaskBook implements ReadOnlyTaskBook {
     private List<XmlAdaptedItem> items;
     @XmlElement
     private List<Tag> tags;
+
+    private static final Logger logger = LogsCenter.getLogger(XmlTaskBookStorage.class);
 
     {
         items = new ArrayList<>();
@@ -62,6 +66,7 @@ public class XmlSerializableTaskBook implements ReadOnlyTaskBook {
             try {
                 lists.add(i.toModelType());
             } catch (IllegalValueException e) {
+                logger.warning("Could not add item from XML list");
             }
         }
         return lists;

--- a/src/test/java/guitests/UndoCommandTest.java
+++ b/src/test/java/guitests/UndoCommandTest.java
@@ -7,6 +7,8 @@ import seedu.sudowudo.testutil.TestItem;
 import seedu.sudowudo.testutil.TestUtil;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Arrays;
+
 /**
  * GUI test for undo commands for each: Add, Delete, Clear, Done and Edit command
  * @author Darren Le
@@ -39,12 +41,13 @@ public class UndoCommandTest extends TaskBookGuiTest {
     public void undo_delete() {
     	// delete the first item from the list
     	TestItem[] currentList = td.getTypicalItems();
+    	Arrays.sort(currentList);
     	int targetIndex = 1;
         commandBox.runCommand("delete " + targetIndex);
 
         // undo should succeed
         commandBox.runCommand("undo");
-        assertResultMessage("Undo delete task: Dover Road");
+        assertResultMessage("Undo delete task: " + currentList[targetIndex-1]);
         
         // delete a bad command
         commandBox.runCommand("delete " + currentList.length + 2);
@@ -53,6 +56,7 @@ public class UndoCommandTest extends TaskBookGuiTest {
         commandBox.runCommand("undo");
         assertResultMessage(UndoCommand.MESSAGE_FAILURE);
     }
+    
     
     @Test
     public void undo_clear() {
@@ -68,12 +72,13 @@ public class UndoCommandTest extends TaskBookGuiTest {
     @Test
     public void undo_done() {
     	TestItem[] currentList = td.getTypicalItems();
+    	Arrays.sort(currentList);
         int targetIndex = 1;
         commandBox.runCommand("done " + targetIndex);
         
         // undo should succeed
         commandBox.runCommand("undo");
-        assertResultMessage("Undo set done task: Dover Road");
+        assertResultMessage("Undo set done task: " + currentList[targetIndex-1]);
     }
  
     private void assertNotFound(TestItem itemToFind, TestItem... currentList) {

--- a/src/test/java/seedu/sudowudo/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/sudowudo/logic/LogicManagerTest.java
@@ -194,6 +194,18 @@ public class LogicManagerTest<E> {
 
         assertCommandBehavior("clear", ClearCommand.MESSAGE_SUCCESS, new TaskBook(), Collections.emptyList());
     }
+    
+    //@@author A0131560U
+    @Test
+    public void execute_addInvalidPeriod_errorMessageShown() throws Exception {
+        assertCommandBehavior("add \"invalid\" from today till yesterday", Item.MESSAGE_DATE_CONSTRAINTS);
+    }
+    
+    //@@author A0131560U
+    @Test
+    public void execute_addInvalidDescription_errorMessageShown() throws Exception {
+        assertCommandBehavior("add \"!\"", Description.MESSAGE_NAME_CONSTRAINTS);
+    }
 
     //@@author A0144750J
     @Test
@@ -205,6 +217,7 @@ public class LogicManagerTest<E> {
         assertCommandBehavior("add wrong args format", expectedMessage);
         assertCommandBehavior("add wrong args \"format\"", expectedMessage);
     }
+    
 
     //@@author A0144750J
     @Test
@@ -233,7 +246,6 @@ public class LogicManagerTest<E> {
 
         assertCommandBehavior(helper.generateAddCommand(toBeAdded),
                 String.format(AddCommand.MESSAGE_SUCCESS, toBeAdded), expectedTB, expectedTB.getItemList());
-
     }
 
     @Test
@@ -722,6 +734,33 @@ public class LogicManagerTest<E> {
     }
     //@@author
 
+    //@@author A0131560U
+    @Test
+    public void execute_editInvalidDescription_errorMessageShown() throws Exception {
+        TestDataHelper helper = new TestDataHelper();
+        Item initial = helper.workingItemWithDates("valid", LocalDateTime.of(2016, 10, 10, 10, 10, 10),
+                LocalDateTime.of(2016, 11, 11, 11, 11, 11));
+        List<Item> expectedList = helper.generateItemList(initial);
+        helper.addToModel(model, expectedList);
+        TaskBook expectedTB = helper.generateTaskBook(expectedList);
+        String newDescription = "invalid!!";
+        assertCommandBehavior("edit 1 desc:" + newDescription, Description.MESSAGE_NAME_CONSTRAINTS, expectedTB, expectedList);
+    }
+    
+    //@@author A0131560U
+    @Test
+    public void execute_editInvalidDates_errorMessageShown() throws Exception {
+        TestDataHelper helper = new TestDataHelper();
+        Item initial = helper.workingItemWithDates("valid", LocalDateTime.of(2016, 10, 10, 10, 10, 10),
+                                                            LocalDateTime.of(2016, 11, 11, 11, 11, 11));
+        List<Item> expectedList = helper.generateItemList(initial);
+        helper.addToModel(model, expectedList);
+        TaskBook expectedTB = helper.generateTaskBook(expectedList);
+        assertCommandBehavior("edit 1 period: today till yesterday", Item.MESSAGE_DATE_CONSTRAINTS, expectedTB, expectedList);
+        assertCommandBehavior("edit 1 start: january 1st 2017", Item.MESSAGE_DATE_CONSTRAINTS, expectedTB, expectedList);
+        assertCommandBehavior("edit 1 end: january 1st 2015", Item.MESSAGE_DATE_CONSTRAINTS, expectedTB, expectedList);
+    }
+
     //@@author A0147609X
     /**
      * @throws Exception
@@ -774,7 +813,7 @@ public class LogicManagerTest<E> {
 
         private Item aLongEvent() throws Exception {
             Description description = new Description("A long event");
-            LocalDateTime startDate = LocalDateTime.of(2016, 10, 10, 10, 10);
+            LocalDateTime startDate = LocalDateTime.of(2014, 10, 10, 10, 10);
             LocalDateTime endDate = LocalDateTime.of(2016, 12, 12, 12, 12);
             return new Item(description, startDate, endDate, new UniqueTagList());
         }

--- a/src/test/java/seedu/sudowudo/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/sudowudo/logic/LogicManagerTest.java
@@ -760,6 +760,23 @@ public class LogicManagerTest<E> {
         assertCommandBehavior("edit 1 start: january 1st 2017", Item.MESSAGE_DATE_CONSTRAINTS, expectedTB, expectedList);
         assertCommandBehavior("edit 1 end: january 1st 2015", Item.MESSAGE_DATE_CONSTRAINTS, expectedTB, expectedList);
     }
+    
+    //@@author A0131560U
+    @Test
+    public void execute_editPeriod_success() throws Exception {
+        TestDataHelper helper = new TestDataHelper();
+        Item initial = helper.workingItemWithDates("valid", LocalDateTime.of(2016, 10, 10, 10, 10, 10),
+                                                            LocalDateTime.of(2016, 11, 11, 11, 11, 11));
+        Item target = helper.workingItemWithDates("valid", LocalDateTime.of(2015, 10, 10, 10, 10, 10),
+                                                            LocalDateTime.of(2015, 11, 11, 11, 11, 11));
+        List<Item> initialList = helper.generateItemList(initial);
+        List<Item> targetList = helper.generateItemList(target);
+        helper.addToModel(model, initialList);
+        TaskBook expectedTB = helper.generateTaskBook(targetList);
+        assertCommandBehavior("edit 1 period: 2015 10 10 10 10:10 to 2015 11 11 11 11:11",
+                    String.format(EditCommand.MESSAGE_SUCCESS, target), expectedTB, targetList);
+
+    }
 
     //@@author A0147609X
     /**

--- a/src/test/java/seedu/sudowudo/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/sudowudo/logic/LogicManagerTest.java
@@ -25,7 +25,6 @@ import com.google.common.eventbus.Subscribe;
 import seedu.sudowudo.commons.core.EventsCenter;
 import seedu.sudowudo.commons.core.Messages;
 import seedu.sudowudo.commons.events.model.TaskBookChangedEvent;
-import seedu.sudowudo.commons.events.ui.JumpToListRequestEvent;
 import seedu.sudowudo.commons.events.ui.ShowHelpRequestEvent;
 import seedu.sudowudo.commons.exceptions.DuplicateDataException;
 import seedu.sudowudo.commons.exceptions.IllegalValueException;
@@ -69,7 +68,6 @@ public class LogicManagerTest<E> {
     // These are for checking the correctness of the events raised
     private ReadOnlyTaskBook latestSavedTaskBook;
     private boolean helpShown;
-    private int targetedJumpIndex;
 
     @Subscribe
     private void handleLocalModelChangedEvent(TaskBookChangedEvent tbce) {
@@ -81,13 +79,8 @@ public class LogicManagerTest<E> {
         helpShown = true;
     }
 
-    @Subscribe
-    private void handleJumpToListRequestEvent(JumpToListRequestEvent je) {
-        targetedJumpIndex = je.targetIndex;
-    }
-
     @Before
-    public void setup() {
+    public void setUp() {
         model = new ModelManager();
         String tempTaskBookFile = saveFolder.getRoot().getPath() + "TempTaskBook.xml";
         String tempPreferencesFile = saveFolder.getRoot().getPath() + "TempPreferences.json";
@@ -98,11 +91,10 @@ public class LogicManagerTest<E> {
         latestSavedTaskBook = new TaskBook(model.getTaskBook());
         
         helpShown = false;
-        targetedJumpIndex = -1; // non yet
     }
 
     @After
-    public void teardown() {
+    public void tearDown() {
         EventsCenter.clearSubscribers();
     }
 
@@ -236,8 +228,6 @@ public class LogicManagerTest<E> {
     @Test
     // @@author A0131560U
     public void setTags_duplicateTags_duplicateDeleted() throws Exception {
-        UniqueTagList tags;
-
         thrown.expect(DuplicateDataException.class);
         TestDataHelper helper = new TestDataHelper();
         Item toBeAdded = helper.workingItemWithTags("important", "incredible", "important", "priority1");
@@ -282,7 +272,6 @@ public class LogicManagerTest<E> {
     // @@author A0131560U
     public void setTags_tagNotMarkedWithHashtag_successfulWithoutTags() {
         try {
-            UniqueTagList tags;
             TestDataHelper helper = new TestDataHelper();
             Item toBeAdded = helper.workingItemWithTags();
             TaskBook expectedTB = new TaskBook();
@@ -792,7 +781,7 @@ public class LogicManagerTest<E> {
         model.resetData(new TaskBook());
         model.addItem(itemList.get(0));
 
-        String expectedMessage = String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE);
+        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE);
         assertCommandBehavior("edit 1", expectedMessage, model.getTaskBook(), itemList);
     }
     //@@author
@@ -850,7 +839,8 @@ public class LogicManagerTest<E> {
         //@@author A0131560U
         private Item workingItemWithDates(String desc, LocalDateTime... times) throws Exception {
             Description description = new Description(desc);
-            LocalDateTime startDate = null, endDate = null;
+            LocalDateTime startDate = null,
+                          endDate = null;
             if (times.length > 0){
                  startDate = times[0];
             }
@@ -948,7 +938,7 @@ public class LogicManagerTest<E> {
         /**
          * Adds the given list of Items to the given model
          */
-        void addToModel(Model model, List<Item> itemsToAdd) throws Exception {
+        private void addToModel(Model model, List<Item> itemsToAdd) throws Exception {
             for (Item p : itemsToAdd) {
                 model.addItem(p);
             }
@@ -957,7 +947,7 @@ public class LogicManagerTest<E> {
         /**
          * Generates a list of Items based on the flags.
          */
-        List<Item> generateItemList(int numGenerated) throws Exception {
+        private List<Item> generateItemList(int numGenerated) throws Exception {
             List<Item> items = new ArrayList<>();
             for (int i = 1; i <= numGenerated; i++) {
                 items.add(generateItem(i));
@@ -965,7 +955,7 @@ public class LogicManagerTest<E> {
             return items;
         }
 
-        List<Item> generateItemList(Item... items) {
+        private List<Item> generateItemList(Item... items) {
             List<Item> itemList = Arrays.asList(items);
             Collections.sort(itemList);
             return itemList;
@@ -975,7 +965,7 @@ public class LogicManagerTest<E> {
          * Generates a Item object with given description. Other fields will
          * have some dummy values.
          */
-        Item generateItemWithName(String desc) throws Exception {
+        private Item generateItemWithName(String desc) throws Exception {
             return new Item(new Description(desc), new UniqueTagList(new Tag("tag")));
         }
     }

--- a/src/test/java/seedu/sudowudo/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/sudowudo/logic/LogicManagerTest.java
@@ -762,7 +762,7 @@ public class LogicManagerTest<E> {
         List<Item> targetList = helper.generateItemList(target);
         helper.addToModel(model, initialList);
         TaskBook expectedTB = helper.generateTaskBook(targetList);
-        assertCommandBehavior("edit 1 period: 2015 10 10 10 10:10 to 2015 11 11 11 11:11",
+        assertCommandBehavior("edit 1 period: October 10 2015 to October 11 2015",
                     String.format(EditCommand.MESSAGE_SUCCESS, target), expectedTB, targetList);
 
     }
@@ -839,8 +839,8 @@ public class LogicManagerTest<E> {
         //@@author A0131560U
         private Item workingItemWithDates(String desc, LocalDateTime... times) throws Exception {
             Description description = new Description(desc);
-            LocalDateTime startDate = null,
-                          endDate = null;
+            LocalDateTime startDate = null;
+            LocalDateTime endDate = null;
             if (times.length > 0){
                  startDate = times[0];
             }

--- a/src/test/java/seedu/sudowudo/testutil/ItemBuilder.java
+++ b/src/test/java/seedu/sudowudo/testutil/ItemBuilder.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import seedu.sudowudo.commons.exceptions.IllegalValueException;
 import seedu.sudowudo.logic.parser.DateTimeParser;
 import seedu.sudowudo.model.item.Description;
+import seedu.sudowudo.model.item.Item;
 import seedu.sudowudo.model.tag.Tag;
 import seedu.sudowudo.model.tag.UniqueTagList;
 

--- a/src/test/java/seedu/sudowudo/testutil/ItemBuilder.java
+++ b/src/test/java/seedu/sudowudo/testutil/ItemBuilder.java
@@ -25,7 +25,11 @@ public class ItemBuilder {
     	DateTimeParser parser = new DateTimeParser(startdate);
 		LocalDateTime startTimeObj = parser.extractStartDate();
 		LocalDateTime endTimeObj = parser.extractStartDate();
-		this.item.setStartDate(startTimeObj);
+
+		// if the item is an event
+		if (startTimeObj != null && !startTimeObj.equals(endTimeObj)){
+		    this.item.setStartDate(startTimeObj);
+		}
 		this.item.setEndDate(endTimeObj);
 		return this;
     }

--- a/src/test/java/seedu/sudowudo/testutil/ItemBuilder.java
+++ b/src/test/java/seedu/sudowudo/testutil/ItemBuilder.java
@@ -24,10 +24,10 @@ public class ItemBuilder {
     public ItemBuilder withDates(String startdate) throws IllegalValueException{
     	DateTimeParser parser = new DateTimeParser(startdate);
 		LocalDateTime startTimeObj = parser.extractStartDate();
-		LocalDateTime endTimeObj = parser.extractStartDate();
+		LocalDateTime endTimeObj = parser.extractEndDate();
 
 		// if the item is an event
-		if (startTimeObj != null && !startTimeObj.equals(endTimeObj)){
+		if (item.is(Item.Type.EVENT)){
 		    this.item.setStartDate(startTimeObj);
 		}
 		this.item.setEndDate(endTimeObj);

--- a/src/test/java/seedu/sudowudo/testutil/TaskBookBuilder.java
+++ b/src/test/java/seedu/sudowudo/testutil/TaskBookBuilder.java
@@ -1,9 +1,7 @@
 package seedu.sudowudo.testutil;
 
-import seedu.sudowudo.commons.exceptions.IllegalValueException;
 import seedu.sudowudo.model.item.Item;
 import seedu.sudowudo.model.item.UniqueItemList;
-import seedu.sudowudo.model.tag.Tag;
 import seedu.sudowudo.model.TaskBook;
 
 /**
@@ -24,13 +22,6 @@ public class TaskBookBuilder {
         taskBook.addItem(item);
         return this;
     }
-    
-    /*
-    public TaskBookBuilder withTag(String tagName) throws IllegalValueException {
-        taskBook.addTag(new Tag(tagName));
-        return this;
-    }
-    */
     
     public TaskBook build(){
         return taskBook;

--- a/src/test/java/seedu/sudowudo/testutil/TestItem.java
+++ b/src/test/java/seedu/sudowudo/testutil/TestItem.java
@@ -9,6 +9,7 @@ import java.util.Observable;
 import seedu.sudowudo.logic.parser.DateTimeParser;
 import seedu.sudowudo.model.item.Description;
 import seedu.sudowudo.model.item.ReadOnlyItem;
+import seedu.sudowudo.model.item.Item.Type;
 import seedu.sudowudo.model.tag.UniqueTagList;
 
 public class TestItem extends Observable implements ReadOnlyItem, Comparable<TestItem>{
@@ -91,9 +92,8 @@ public class TestItem extends Observable implements ReadOnlyItem, Comparable<Tes
         return description.toString();
     }
 
-    @Override
-    public void setIsDone(boolean doneness) {
-        this.isDone = doneness;
+    public void setIsDone(boolean isDone) {
+        this.isDone = isDone;
     }
     
     //@@author A0144750J
@@ -119,26 +119,23 @@ public class TestItem extends Observable implements ReadOnlyItem, Comparable<Tes
 
 	// @@author A0092390E-repeated
     @Override
-    public boolean is(String query) {
-        query = query.toLowerCase();
+    public boolean is(Type query) {
         switch (query) {
-        case "done":
+        case DONE:
             return this.getIsDone();
-        case "undone":
+        case UNDONE:
             return !this.getIsDone();
-        case "event":
+        case EVENT:
             return this.getStartDate() != null;
-        case "task":
+        case TASK:
             return this.getStartDate() == null;
-        case "overdue":
-            return this.getEndDate() != null && this.getIsDone() == false
-                    && this.getEndDate().isAfter(LocalDateTime.now());
-        case "item":
+        case OVERDUE:
+            return this.is(Type.TASK) && this.getEndDate() != null && this.getEndDate().isBefore(LocalDateTime.now());
+        case ITEM:
             return true;
         default:
             return false;
         }
-
     }
 
 

--- a/src/test/java/seedu/sudowudo/testutil/TestItem.java
+++ b/src/test/java/seedu/sudowudo/testutil/TestItem.java
@@ -117,7 +117,7 @@ public class TestItem extends Observable implements ReadOnlyItem, Comparable<Tes
         return sb.toString();
     }
 
-	// @@author A0092390E
+	// @@author A0092390E-repeated
     @Override
     public boolean is(String query) {
         query = query.toLowerCase();


### PR DESCRIPTION
Fixes #80, incidentally fixes #99 
Prevents adding and editing an event to give it a `startDate` that is after its `endDate`, or an `endDate` that is after its `startDate`