### PR TITLE
Apply singleton pattern to DateTimeParser

### DIFF
--- a/src/main/java/seedu/sudowudo/commons/util/ListUtil.java
+++ b/src/main/java/seedu/sudowudo/commons/util/ListUtil.java
@@ -13,32 +13,34 @@ public class ListUtil {
 
     private static ListUtil instance = new ListUtil();
 
-    //@@author A0131560U
-    private ListUtil(){};
-    
-    public static ListUtil getInstance(){
+    // @@author A0131560U
+    private ListUtil() {
+    };
+
+    public static ListUtil getInstance() {
         return instance;
     }
 
-    public void updateFilteredItemList(FilteredList<Item> filteredItems, Set<String> keywords, Predicate defaultPredicate){
-        updateFilteredItemList(filteredItems, new QualifierPredicate(new KeywordQualifier(keywords)).and(defaultPredicate));
+    public void updateFilteredItemList(FilteredList<Item> filteredItems, Set<String> keywords,
+            Predicate defaultPredicate) {
+        updateFilteredItemList(filteredItems,
+                new QualifierPredicate(new KeywordQualifier(keywords)).and(defaultPredicate));
 
     }
-    
-    public Predicate setDefaultPredicate(String taskType){
+
+    public Predicate setDefaultPredicate(String taskType) {
         return new QualifierPredicate(new TypeQualifier(taskType));
     }
-    
+
     // @@author A0092390E
     private void updateFilteredItemList(FilteredList<Item> filteredItems, Predicate pred) {
         filteredItems.setPredicate(pred);
     }
-    
-    //@@author
-    public void updateFilteredItemList(FilteredList<Item> filteredItems, Set<String> keywords) {
-        updateFilteredItemList(filteredItems, new QualifierPredicate(new KeywordQualifier(keywords)));        
-    }
 
+    // @@author
+    public void updateFilteredItemList(FilteredList<Item> filteredItems, Set<String> keywords) {
+        updateFilteredItemList(filteredItems, new QualifierPredicate(new KeywordQualifier(keywords)));
+    }
 
     private class QualifierPredicate implements Predicate<ReadOnlyItem> {
 
@@ -67,9 +69,11 @@ public class ListUtil {
         String toString();
     }
 
-    //@@author A0131560U
+    // @@author A0131560U
     /**
-     * A Qualifier class that particularly checks for Item Type (e.g. Task, Event, Done).
+     * A Qualifier class that particularly checks for Item Type (e.g. Task,
+     * Event, Done).
+     * 
      * @author craa
      *
      */
@@ -93,9 +97,10 @@ public class ListUtil {
 
     }
 
-    //@@author A0131560U
+    // @@author A0131560U
     /**
      * A Qualifier class that particularly checks a set of keywords.
+     * 
      * @author craa
      *
      */
@@ -125,7 +130,9 @@ public class ListUtil {
 
     // @@author A0092390E-idea
     /**
-     * An anonymous class that holds a keyword. This keyword is used to search against items.
+     * An anonymous class that holds a keyword. This keyword is used to search
+     * against items.
+     * 
      * @author craa
      *
      */
@@ -136,9 +143,11 @@ public class ListUtil {
             keyword = _keyword;
         }
 
-        //@@author A0131560U
+        // @@author A0131560U
         /**
-         * Returns true if the item matches the keyword in this instance of Keyword.
+         * Returns true if the item matches the keyword in this instance of
+         * Keyword.
+         * 
          * @param item
          * @return
          */
@@ -154,34 +163,39 @@ public class ListUtil {
 
         /**
          * Checks if the item's start or end date matches the keyword.
+         * 
          * @param item
          * @return
          */
         private boolean matchesDates(ReadOnlyItem item) {
-            DateTimeParser parseDate = new DateTimeParser(keyword);
+            DateTimeParser parser = DateTimeParser.getInstance();
+            parser.parse(keyword);
+
             return ((item.getStartDate() != null
-                    && DateTimeParser.isSameDay(item.getStartDate(), parseDate.extractStartDate())
+                    && DateTimeParser.isSameDay(item.getStartDate(), parser.extractStartDate())
                     || (item.getEndDate() != null
-                            && DateTimeParser.isSameDay(item.getEndDate(), parseDate.extractStartDate()))));
+                            && DateTimeParser.isSameDay(item.getEndDate(), parser.extractStartDate()))));
         }
 
         /**
          * Checks if the item's tags (or types, if the tag string actually
          * aliases to a type meta-tag) match the keyword.
+         * 
          * @param item
          * @return
          */
         private boolean matchesTags(ReadOnlyItem item) {
             keyword = keyword.replaceFirst(Parser.COMMAND_TAG_PREFIX, "");
-            if (isKeywordType()){
+            if (isKeywordType()) {
                 return item.is(keyword);
             }
 
-            return StringUtil.containsIgnoreCase(item.getTags().listTags(),keyword);
+            return StringUtil.containsIgnoreCase(item.getTags().listTags(), keyword);
         }
 
         /**
          * Checks if the item's description matches the keyword
+         * 
          * @param item
          * @return
          */
@@ -189,8 +203,8 @@ public class ListUtil {
             return StringUtil.containsIgnoreCase(item.getDescription().getFullDescription(),
                     keyword.replace(Parser.COMMAND_DESCRIPTION_PREFIX, ""));
         }
-        
-        private boolean isKeywordType(){
+
+        private boolean isKeywordType() {
             return Parser.isValidType(keyword);
         }
     }

--- a/src/main/java/seedu/sudowudo/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/sudowudo/logic/commands/AddCommand.java
@@ -19,27 +19,25 @@ import seedu.sudowudo.model.tag.UniqueTagList.DuplicateTagException;
 
 public class AddCommand extends Command {
 
-    private static final String EMPTY_STRING = "";
-
     public static final String COMMAND_WORD = "add";
-
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Adds a task to the to-do list. "
             + "Parameters: \"EVENT_NAME\" from START_TIME to END_TIME on DATE #TAGS"
             + "Example: " + COMMAND_WORD
             + "\"Be awesome\" from 1300 to 2359 on 07/10/2016 #cool #nice";
-
     public static final String MESSAGE_SUCCESS = "New %1$s added: %2$s";
     public static final String MESSAGE_SUCCESS_TIME_NULL = "START or END time not found but new %1$s added!";
     public static final String MESSAGE_DUPLICATE_ITEM = "This task already exists in the to-do list";
     public static final String MESSAGE_UNDO_SUCCESS = "Undo add task: %1$s";
+
     private static final String DEFAULT_ITEM_NAME = "BLOCK";
+    private static final String EMPTY_STRING = "";
+    private static final DateTimeParser dtParser = DateTimeParser.getInstance();
 
     private final Item toAdd;
     private Item toUndoAdd;
     private boolean hasTimeString = false;
     
-    private final DateTimeParser dtparser = DateTimeParser.getInstance();
 
     /**
      * Constructor using raw strings
@@ -88,11 +86,11 @@ public class AddCommand extends Command {
     }
 
     private LocalDateTime setEndDateTime(String timeStr) {
-        return this.dtparser.parse(timeStr).extractEndDate();
+        return dtParser.parse(timeStr).extractEndDate();
     }
 
     private LocalDateTime setStartDateTime(String timeStr) {
-        return this.dtparser.parse(timeStr).extractStartDate();
+        return dtParser.parse(timeStr).extractStartDate();
     }
 
     private Description setDescription(String descriptionStr)

--- a/src/main/java/seedu/sudowudo/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/sudowudo/logic/commands/AddCommand.java
@@ -38,6 +38,8 @@ public class AddCommand extends Command {
     private final Item toAdd;
     private Item toUndoAdd;
     private boolean hasTimeString = false;
+    
+    private final DateTimeParser dtparser = DateTimeParser.getInstance();
 
     /**
      * Constructor using raw strings
@@ -86,15 +88,11 @@ public class AddCommand extends Command {
     }
 
     private LocalDateTime setEndDateTime(String timeStr) {
-        DateTimeParser parser = new DateTimeParser(timeStr);
-        LocalDateTime endTimeObj = parser.extractEndDate();
-        return endTimeObj;
+        return this.dtparser.parse(timeStr).extractEndDate();
     }
 
     private LocalDateTime setStartDateTime(String timeStr) {
-        DateTimeParser parser = new DateTimeParser(timeStr);
-        LocalDateTime startTimeObj = parser.extractStartDate();
-        return startTimeObj;
+        return this.dtparser.parse(timeStr).extractStartDate();
     }
 
     private Description setDescription(String descriptionStr)

--- a/src/main/java/seedu/sudowudo/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/sudowudo/logic/commands/AddCommand.java
@@ -32,7 +32,7 @@ public class AddCommand extends Command {
 
     private static final String DEFAULT_ITEM_NAME = "BLOCK";
     private static final String EMPTY_STRING = "";
-    private static final DateTimeParser dtParser = DateTimeParser.getInstance();
+    private DateTimeParser dtParser = DateTimeParser.getInstance();
 
     private final Item toAdd;
     private Item toUndoAdd;

--- a/src/main/java/seedu/sudowudo/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/sudowudo/logic/commands/EditCommand.java
@@ -18,7 +18,6 @@ import seedu.sudowudo.model.tag.UniqueTagList;
 public class EditCommand extends Command {
 
     public static final String COMMAND_WORD = "edit";
-
     public static final String MESSAGE_USAGE = COMMAND_WORD + "... edit ..." + ": Edits an existing item.\n"
             + "Syntax: edit CONTEXT_ID FIELD:NEW_DETAIL\n" + "Example: " + COMMAND_WORD
             + " 2 start:tomorrow 6pm";
@@ -29,14 +28,13 @@ public class EditCommand extends Command {
     public static final String MESSAGE_UNDO_SUCCESS = "Undo edit task: %1$s";
     public static final String MESSAGE_UNDO_FAILURE = "Failed to undo edit task: %1$s";
 
-    public static final String[] ALLOWED_FIELDS = { "desc", "description", "start", "end", "by", "period" };
+    public final int targetIndex;
+
+    private static final DateTimeParser dtParser = DateTimeParser.getInstance();
 
     private Item itemToModify;
     private Item previousTemplate;
-    public final int targetIndex;
     private ArrayList<String[]> editFields;
-
-    private final DateTimeParser dtparser = DateTimeParser.getInstance();
 
     // @@author A0092390E
     /**
@@ -93,16 +91,16 @@ public class EditCommand extends Command {
                 model.setItemDesc(itemToModify, newFieldDetail);
                 break;
             case "start":
-                model.setItemStart(itemToModify, this.dtparser.parse(newFieldDetail).extractStartDate());
+                model.setItemStart(itemToModify, dtParser.parse(newFieldDetail).extractStartDate());
                 break;
             case "end":
             case "by":
-                model.setItemEnd(itemToModify, this.dtparser.parse(newFieldDetail).extractStartDate());
+                model.setItemEnd(itemToModify, dtParser.parse(newFieldDetail).extractStartDate());
                 break;
             case "period":
-                this.dtparser.parse(newFieldDetail);
-                model.setItemStart(itemToModify, this.dtparser.extractStartDate());
-                model.setItemEnd(itemToModify, this.dtparser.extractEndDate());
+                dtParser.parse(newFieldDetail);
+                model.setItemStart(itemToModify, dtParser.extractStartDate());
+                model.setItemEnd(itemToModify, dtParser.extractEndDate());
                 break;
             default:
                 // field names not valid

--- a/src/main/java/seedu/sudowudo/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/sudowudo/logic/commands/EditCommand.java
@@ -30,7 +30,7 @@ public class EditCommand extends Command {
 
     public final int targetIndex;
 
-    private static final DateTimeParser dtParser = DateTimeParser.getInstance();
+    private DateTimeParser dtParser = DateTimeParser.getInstance();
 
     private Item itemToModify;
     private Item previousTemplate;

--- a/src/main/java/seedu/sudowudo/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/sudowudo/logic/commands/EditCommand.java
@@ -19,10 +19,9 @@ public class EditCommand extends Command {
 
     public static final String COMMAND_WORD = "edit";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + "... edit ..."
-            + ": Edits an existing item.\n"
-            + "Syntax: edit CONTEXT_ID FIELD:NEW_DETAIL\n" + "Example: "
-            + COMMAND_WORD + " 2 start:tomorrow 6pm";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + "... edit ..." + ": Edits an existing item.\n"
+            + "Syntax: edit CONTEXT_ID FIELD:NEW_DETAIL\n" + "Example: " + COMMAND_WORD
+            + " 2 start:tomorrow 6pm";
 
     public static final String MESSAGE_SUCCESS = "Successfully edited: %1$s";
     public static final String MESSAGE_DUPLICATE_ITEM = "This task already exists in the to-do list";
@@ -30,15 +29,16 @@ public class EditCommand extends Command {
     public static final String MESSAGE_UNDO_SUCCESS = "Undo edit task: %1$s";
     public static final String MESSAGE_UNDO_FAILURE = "Failed to undo edit task: %1$s";
 
-    public static final String[] ALLOWED_FIELDS = { "desc", "description",
-            "start", "end", "by", "period" };
+    public static final String[] ALLOWED_FIELDS = { "desc", "description", "start", "end", "by", "period" };
 
     private Item itemToModify;
     private Item previousTemplate;
     public final int targetIndex;
     private ArrayList<String[]> editFields;
 
-    //@@author A0092390E
+    private final DateTimeParser dtparser = DateTimeParser.getInstance();
+
+    // @@author A0092390E
     /**
      * Constructor using raw strings
      * 
@@ -49,8 +49,7 @@ public class EditCommand extends Command {
      *            which is a field:value pair
      * @throws IllegalValueException
      */
-    public EditCommand(Integer index, ArrayList<String> arguments)
-            throws IllegalValueException {
+    public EditCommand(Integer index, ArrayList<String> arguments) throws IllegalValueException {
         this.targetIndex = index;
         assert arguments.size() != 0;
 
@@ -59,12 +58,11 @@ public class EditCommand extends Command {
             editFields.add(argument.split(":", 2));
         }
 
-        previousTemplate = new Item(new Description("dummy"), null, null,
-                new UniqueTagList());
+        previousTemplate = new Item(new Description("dummy"), null, null, new UniqueTagList());
     }
-    //@@author
+    // @@author
 
-    //@@author A0147609X
+    // @@author A0147609X
     /**
      * Executes the edit command.
      * 
@@ -77,8 +75,7 @@ public class EditCommand extends Command {
         if (lastShownList.size() < targetIndex) {
             indicateAttemptToExecuteIncorrectCommand();
             hasUndo = false;
-            return new CommandResult(
-                    Messages.MESSAGE_INVALID_ITEM_DISPLAYED_INDEX);
+            return new CommandResult(Messages.MESSAGE_INVALID_ITEM_DISPLAYED_INDEX);
         }
 
         itemToModify = lastShownList.get(this.targetIndex - 1);
@@ -86,38 +83,37 @@ public class EditCommand extends Command {
         // deep copy the item to a template for undo
         previousTemplate = itemToModify.deepCopy();
 
-        for (String[] editField : editFields) {
-            switch (editField[0]) {
-                case "desc":
-                case "description":
-                    model.setItemDesc(itemToModify, editField[1]);
-                    break;
-                case "start":
-                    model.setItemStart(itemToModify,
-                            new DateTimeParser(editField[1])
-                                    .extractStartDate());
-                    break;
-                case "end":
-                case "by":
-                    model.setItemEnd(itemToModify,
-                            new DateTimeParser(editField[1]).extractStartDate());
-                    break;
-                case "period":
-                    DateTimeParser parser = new DateTimeParser(editField[1]);
-                    model.setItemStart(itemToModify, parser.extractStartDate());
-                    model.setItemEnd(itemToModify, parser.extractEndDate());
-                    break;
-                default:
-                    // field names not valid
-                    return new CommandResult(MESSAGE_INVALID_FIELD);
+        for (String[] editStruct : editFields) {
+            String fieldToEdit = editStruct[0];
+            String newFieldDetail = editStruct[1];
+
+            switch (fieldToEdit) {
+            case "desc":
+            case "description":
+                model.setItemDesc(itemToModify, newFieldDetail);
+                break;
+            case "start":
+                model.setItemStart(itemToModify, this.dtparser.parse(newFieldDetail).extractStartDate());
+                break;
+            case "end":
+            case "by":
+                model.setItemEnd(itemToModify, this.dtparser.parse(newFieldDetail).extractStartDate());
+                break;
+            case "period":
+                this.dtparser.parse(newFieldDetail);
+                model.setItemStart(itemToModify, this.dtparser.extractStartDate());
+                model.setItemEnd(itemToModify, this.dtparser.extractEndDate());
+                break;
+            default:
+                // field names not valid
+                return new CommandResult(MESSAGE_INVALID_FIELD);
             }
         }
         hasUndo = true;
-        return new CommandResult(String.format(MESSAGE_SUCCESS, itemToModify),
-                itemToModify);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, itemToModify), itemToModify);
 
     }
-    //@@author
+    // @@author
 
     /**
      * @@author A0144750J
@@ -126,15 +122,12 @@ public class EditCommand extends Command {
     public CommandResult undo() {
         // deep copy the item to a template for undo
 
-        model.setItemDesc(itemToModify,
-                previousTemplate.getDescription().getFullDescription());
+        model.setItemDesc(itemToModify, previousTemplate.getDescription().getFullDescription());
         model.setItemStart(itemToModify, previousTemplate.getStartDate());
         model.setItemEnd(itemToModify, previousTemplate.getEndDate());
         itemToModify.setIsDone(previousTemplate.getIsDone());
         itemToModify.setTags(previousTemplate.getTags());
-        return new CommandResult(
-                String.format(MESSAGE_UNDO_SUCCESS, itemToModify),
-                itemToModify);
+        return new CommandResult(String.format(MESSAGE_UNDO_SUCCESS, itemToModify), itemToModify);
     }
 
 }

--- a/src/main/java/seedu/sudowudo/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/sudowudo/logic/parser/DateTimeParser.java
@@ -64,14 +64,13 @@ public class DateTimeParser {
     public static final DateTimeFormatter SHORT_DAYOFWEEK = DateTimeFormatter
             .ofPattern("EEE");
 
-    public static DateTimeParser dtparser = new DateTimeParser();
+    public static DateTimeParser INSTANCE = new DateTimeParser();
     
     public static DateTimeParser getInstance() {
-        return dtparser;
+        return INSTANCE;
     }
     
-    public DateTimeParser() {
-    }
+    private DateTimeParser() {}
     
     /**
      * Uses the DateTimeParser service to parse a string containing possible

--- a/src/main/java/seedu/sudowudo/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/sudowudo/logic/parser/DateTimeParser.java
@@ -16,7 +16,8 @@ import org.ocpsoft.prettytime.nlp.parse.DateGroup;
 
 //@@author A0147609X
 /**
- * For parsing dates and times in Sudowudo command input
+ * For parsing dates and times in Sudowudo command input.
+ * Singleton pattern!
  * 
  * @author darren
  */
@@ -63,15 +64,30 @@ public class DateTimeParser {
     public static final DateTimeFormatter SHORT_DAYOFWEEK = DateTimeFormatter
             .ofPattern("EEE");
 
-    public DateTimeParser(String input) {
+    public static DateTimeParser dtparser = new DateTimeParser();
+    
+    public static DateTimeParser getInstance() {
+        return dtparser;
+    }
+    
+    public DateTimeParser() {
+    }
+    
+    /**
+     * Uses the DateTimeParser service to parse a string containing possible
+     * datetime tokens (in natural language).
+     * 
+     * @param input
+     */
+    public void parse(String input) {
         assert input != null;
-        assert input.isEmpty() != true;
 
         this.datetime = input;
 
         // perform parsing
         this.dategroups = DateTimeParser.parser.parseSyntax(input);
         this.dates = DateTimeParser.parser.parse(input);
+        
     }
 
     public LocalDateTime extractStartDate() {

--- a/src/main/java/seedu/sudowudo/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/sudowudo/logic/parser/DateTimeParser.java
@@ -78,7 +78,7 @@ public class DateTimeParser {
      * 
      * @param input
      */
-    public void parse(String input) {
+    public DateTimeParser parse(String input) {
         assert input != null;
 
         this.datetime = input;
@@ -87,6 +87,7 @@ public class DateTimeParser {
         this.dategroups = DateTimeParser.parser.parseSyntax(input);
         this.dates = DateTimeParser.parser.parse(input);
         
+        return this;
     }
 
     public LocalDateTime extractStartDate() {

--- a/src/main/java/seedu/sudowudo/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/sudowudo/logic/parser/DateTimeParser.java
@@ -21,6 +21,9 @@ import org.ocpsoft.prettytime.nlp.parse.DateGroup;
  * @author darren
  */
 public class DateTimeParser {
+    private static final int FIRST_DATETIME_TOKEN = 0;
+    private static final int SECOND_DATETIME_TOKEN = 1;
+
     // the part of the command that contains the temporal part of the command
     private String datetime;
 
@@ -78,7 +81,7 @@ public class DateTimeParser {
             return null;
         }
 
-        return changeDateToLocalDateTime(this.dates.get(0));
+        return changeDateToLocalDateTime(this.dates.get(FIRST_DATETIME_TOKEN));
     }
 
     public LocalDateTime extractEndDate() {
@@ -88,16 +91,16 @@ public class DateTimeParser {
             return null;
         }
 
-        return changeDateToLocalDateTime(this.dates.get(1));
+        return changeDateToLocalDateTime(this.dates.get(SECOND_DATETIME_TOKEN));
     }
 
     public boolean isRecurring() {
-        return this.dategroups.get(0).isRecurring();
+        return this.dategroups.get(FIRST_DATETIME_TOKEN).isRecurring();
     }
 
     public LocalDateTime getRecurEnd() {
         return changeDateToLocalDateTime(
-                this.dategroups.get(0).getRecursUntil());
+                this.dategroups.get(FIRST_DATETIME_TOKEN).getRecursUntil());
     }
 
     /**

--- a/src/main/java/seedu/sudowudo/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/sudowudo/logic/parser/DateTimeParser.java
@@ -22,27 +22,9 @@ import org.ocpsoft.prettytime.nlp.parse.DateGroup;
  * @author darren
  */
 public class DateTimeParser {
-    private static final int FIRST_DATETIME_TOKEN = 0;
-    private static final int SECOND_DATETIME_TOKEN = 1;
-
-    // the part of the command that contains the temporal part of the command
-    private String datetime;
-
-    // PrettyTimeParser object
-    // careful of name collision with our own Parser object
-    private static PrettyTimeParser parser = new PrettyTimeParser();
-
-    // PrettyTime formatter
-    private static PrettyTime prettytime = new PrettyTime();
-
-    // result from parser
-    private List<DateGroup> dategroups;
-    private List<Date> dates;
-
+    // handy strings for making pretty dates
     public static final String EMPTY_STRING = "";
     public static final String SINGLE_WHITESPACE = " ";
-
-    // handy strings for making pretty dates
     public static final String TODAY_DATE_REF = "Today";
     public static final String TOMORROW_DATE_REF = "Tomorrow";
     public static final String LAST_WEEK_REF = "Last" + SINGLE_WHITESPACE;
@@ -64,13 +46,31 @@ public class DateTimeParser {
     public static final DateTimeFormatter SHORT_DAYOFWEEK = DateTimeFormatter
             .ofPattern("EEE");
 
-    public static DateTimeParser INSTANCE = new DateTimeParser();
+    public static DateTimeParser instance = new DateTimeParser();
+
+    private static final int FIRST_DATETIME_TOKEN = 0;
+    private static final int SECOND_DATETIME_TOKEN = 1;
+
+    // PrettyTimeParser object
+    // careful of name collision with our own Parser object
+    private static PrettyTimeParser parser = new PrettyTimeParser();
+
+    // PrettyTime formatter
+    private static PrettyTime prettytime = new PrettyTime();
+
+    // the part of the command that contains the temporal part of the command
+    private String datetime;
+
+    // result from parser
+    private List<DateGroup> dategroups;
+    private List<Date> dates;
+
+    private DateTimeParser() {}
     
     public static DateTimeParser getInstance() {
-        return INSTANCE;
+        return instance;
     }
     
-    private DateTimeParser() {}
     
     /**
      * Uses the DateTimeParser service to parse a string containing possible

--- a/src/main/java/seedu/sudowudo/logic/parser/Parser.java
+++ b/src/main/java/seedu/sudowudo/logic/parser/Parser.java
@@ -47,17 +47,19 @@ public class Parser {
     /**
      * Used for initial separation of command word and args.
      */
-    private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<commandWord>\\S+)(?<arguments>.*)");
+    private static final Pattern BASIC_COMMAND_FORMAT = Pattern
+            .compile("(?<commandWord>\\S+)(?<arguments>.*)");
 
     // one or more keywords separated by whitespace
     private static final Pattern KEYWORDS_ARGS_FORMAT = Pattern.compile("(?<keywords>\\S+(?:\\s+\\S+)*)");
 
     // item has description and a string representing time to be processed
     private static final Pattern ITEM_DATA_ARGS_FORMAT = Pattern.compile("(.*)\\\"(.*)\\\"(.*)");
-    
+
     private static final Pattern TASK_DATA_ARGS_FORMAT = Pattern.compile("(.*)\\\"(.*)\\\"");
 
-    private static final Pattern ITEM_EDIT_ARGS_FORMAT = Pattern.compile("(?<targetIndex>\\d+)\\s+(?<arguments>.*)");
+    private static final Pattern ITEM_EDIT_ARGS_FORMAT = Pattern
+            .compile("(?<targetIndex>\\d+)\\s+(?<arguments>.*)");
 
     private static final String TASK_NO_DATE_DATA = "nothing";
     private static final Pattern ITEM_INDEX_ARGS_FORMAT = Pattern.compile("(?<targetIndex>.+)");
@@ -69,7 +71,10 @@ public class Parser {
     private static final Pattern COMMAND_DESCRIPTION_SEARCH_FORMAT = Pattern.compile("\"([^\"]*)\"");
     private static final Pattern COMMAND_TAG_SEARCH_FORMAT = Pattern.compile("#([^ ]+)");
 
-    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter
+            .ofPattern("yyyy-MM-dd HH:mm");
+
+    private final DateTimeParser dtparser = DateTimeParser.getInstance();
 
     public enum Field {
         NAME("name"), START_DATE("start_date"), END_DATE("end_date"), START_TIME("start_time"), END_TIME(
@@ -87,14 +92,14 @@ public class Parser {
     }
 
     private static Parser instance = new Parser();
+
     private Parser() {
     }
-    
-    public static Parser getInstance(){
+
+    public static Parser getInstance() {
         return instance;
     }
 
-    
     /**
      * Parses user input into command for execution.
      *
@@ -105,63 +110,56 @@ public class Parser {
     public Command parseCommand(String userInput) {
         final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
         if (!matcher.matches()) {
-            return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
+            return new IncorrectCommand(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
         }
 
         final String commandWord = matcher.group("commandWord");
         final String arguments = matcher.group("arguments");
         Command toReturn;
+        
         switch (commandWord) {
-
         case AddCommand.COMMAND_WORD:
             toReturn = prepareAdd(arguments);
             break;
-
         case SelectCommand.COMMAND_WORD:
             toReturn = prepareSelect(arguments);
             break;
-
         case DeleteCommand.COMMAND_WORD:
             toReturn = prepareDelete(arguments);
             break;
-
         case ClearCommand.COMMAND_WORD:
             toReturn = new ClearCommand();
             break;
-		case FindCommand.COMMAND_WORD:
-			toReturn = prepareFind(arguments);
-			break;
-
+        case FindCommand.COMMAND_WORD:
+            toReturn = prepareFind(arguments);
+            break;
         case EditCommand.COMMAND_WORD:
             toReturn = prepareEdit(arguments);
             break;
-
         case ListCommand.COMMAND_WORD:
             toReturn = prepareList(arguments);
             break;
-
         case ExitCommand.COMMAND_WORD:
             toReturn = new ExitCommand();
             break;
-
         case HelpCommand.COMMAND_WORD:
             toReturn = new HelpCommand();
             break;
-
         case DoneCommand.COMMAND_WORD:
             toReturn = prepareDone(arguments);
             break;
-            
         case UndoCommand.COMMAND_WORD:
             toReturn = new UndoCommand();
             break;
-
         default:
             toReturn = new IncorrectCommand(MESSAGE_UNKNOWN_COMMAND);
+            break;
         }
+
         toReturn.setRawCommand(userInput);
         return toReturn;
-	};
+    };
 
     /**
      * Parses arguments in the context of the list item command.
@@ -177,7 +175,8 @@ public class Parser {
         } else if (isValidType(argument)) {
             return new ListCommand(argument.trim().toLowerCase());
         } else {
-            return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE));
+            return new IncorrectCommand(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE));
         }
     }
 
@@ -190,7 +189,7 @@ public class Parser {
      */
     public static boolean isValidType(String argument) {
         assert argument != null;
-        try{
+        try {
             Item.Type.valueOf(argument.trim().toUpperCase());
         } catch (IllegalArgumentException iae) {
             return false;
@@ -214,7 +213,8 @@ public class Parser {
                                                                               // string
                                                                               // format
         if (!itemMatch.matches() && !taskMatch.matches()) {
-            return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
+            return new IncorrectCommand(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
         try {
             if (taskMatch.matches()) {
@@ -243,7 +243,8 @@ public class Parser {
         // found
         String postFix = itemMatch.group(COMMAND_TYPE_FIELD_NUMBER).trim();
         if (!postFix.equals(EMPTY_STRING)) {
-            return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
+            return new IncorrectCommand(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
         String description = itemMatch.group(COMMAND_DESCRIPTION_FIELD_NUMBER).trim();
         String timeStr = itemMatch.group(COMMAND_TIME_FIELD_NUMBER).trim();
@@ -263,7 +264,8 @@ public class Parser {
     private Command parseNewTask(final Matcher itemMatch, String args) throws IllegalValueException {
         String postFix = itemMatch.group(COMMAND_TYPE_FIELD_NUMBER).trim();
         if (!postFix.equals(EMPTY_STRING)) {
-            return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
+            return new IncorrectCommand(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
         String description = itemMatch.group(COMMAND_DESCRIPTION_FIELD_NUMBER).trim();
         String argsWithoutDescription = args.replace(description, "");
@@ -271,8 +273,8 @@ public class Parser {
     }
 
     /**
-     * Extracts the new item's tags from the add command's tag arguments
-     * string. Merges duplicate tag strings.
+     * Extracts the new item's tags from the add command's tag arguments string.
+     * Merges duplicate tag strings.
      * 
      * @@author A0131560U
      */
@@ -312,7 +314,8 @@ public class Parser {
             final Set<String> keywordSet = extractKeywords(args);
             return new DeleteCommand(keywordSet);
         } catch (IllegalValueException e) {
-            return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+            return new IncorrectCommand(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
         }
     }
 
@@ -328,7 +331,8 @@ public class Parser {
     private Command prepareDone(String args) {
         Optional<Integer> index = parseIndex(args);
         if (!index.isPresent()) {
-            return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DoneCommand.MESSAGE_USAGE));
+            return new IncorrectCommand(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DoneCommand.MESSAGE_USAGE));
         }
 
         return new DoneCommand(index.get());
@@ -345,7 +349,8 @@ public class Parser {
     private Command prepareSelect(String args) {
         Optional<Integer> index = parseIndex(args);
         if (!index.isPresent()) {
-            return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SelectCommand.MESSAGE_USAGE));
+            return new IncorrectCommand(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, SelectCommand.MESSAGE_USAGE));
         }
 
         return new SelectCommand(index.get());
@@ -370,7 +375,7 @@ public class Parser {
 
     }
 
-    //@@author A0131560U
+    // @@author A0131560U
     /**
      * Parses arguments in the context of the find item command.
      *
@@ -380,20 +385,24 @@ public class Parser {
      * @@author A0131560U
      */
     private Command prepareFind(String args) {
-        try{
+        try {
             final Set<String> keywordSet = extractKeywords(args);
             return new FindCommand(keywordSet);
-        } catch (IllegalValueException ive){
-            return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        } catch (IllegalValueException ive) {
+            return new IncorrectCommand(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
     }
 
-    //@@author A0131560U
+    // @@author A0131560U
     /**
-     * Extracts description, tag and DateTime keywords from args and returns them as a set.
+     * Extracts description, tag and DateTime keywords from args and returns
+     * them as a set.
+     * 
      * @param unfiltered
      * @return
-     * @throws IllegalValueException if arguments are not in the correct format
+     * @throws IllegalValueException
+     *             if arguments are not in the correct format
      */
     private Set<String> extractKeywords(String unfiltered) throws IllegalValueException {
         final Matcher matcher = KEYWORDS_ARGS_FORMAT.matcher(unfiltered.trim());
@@ -410,18 +419,18 @@ public class Parser {
 
         if (!unfiltered.isEmpty()) {
             boolean isDateTimeValid = extractDateTimeFromKeywords(unfiltered, keywordSet);
-            if (!isDateTimeValid){
+            if (!isDateTimeValid) {
                 throw new IllegalValueException("Input does not match expected format for DateTime");
             }
         }
-        
-        if (keywordSet.isEmpty()){
+
+        if (keywordSet.isEmpty()) {
             throw new IllegalValueException("No keywords found");
         }
         return keywordSet;
     }
-    
-    //@@A0092390E
+
+    // @@A0092390E
     /**
      * Parses arguments in the context of the Edit item command
      * 
@@ -432,7 +441,8 @@ public class Parser {
     private Command prepareEdit(String args) {
         final Matcher matcher = ITEM_EDIT_ARGS_FORMAT.matcher(args.trim());
         if (!matcher.matches()) {
-            return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
+            return new IncorrectCommand(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
         }
         int index = Integer.parseInt(matcher.group("targetIndex"));
         ArrayList<String> arguments = parseMultipleParameters(matcher.group("arguments"), ',');
@@ -443,7 +453,7 @@ public class Parser {
         }
     }
 
-    //@@author A0131560U
+    // @@author A0131560U
     /**
      * Extracts a valid DateTime from the provided arguments and adds them to
      * the keywordSet, then returns true. If the arguments do not form a valid
@@ -459,12 +469,13 @@ public class Parser {
         assert args != null;
         assert !args.isEmpty();
         assert keywordSet != null;
-        DateTimeParser dateArgs = new DateTimeParser(args);
 
-        if (dateArgs.extractStartDate() != null) {
-            keywordSet.add(dateArgs.extractStartDate().format(DATE_TIME_FORMATTER));
-            if (dateArgs.extractEndDate() != null) {
-                keywordSet.add(dateArgs.extractEndDate().format(DATE_TIME_FORMATTER));
+        this.dtparser.parse(args);
+
+        if (dtparser.extractStartDate() != null) {
+            keywordSet.add(dtparser.extractStartDate().format(DATE_TIME_FORMATTER));
+            if (dtparser.extractEndDate() != null) {
+                keywordSet.add(dtparser.extractEndDate().format(DATE_TIME_FORMATTER));
             }
             return true;
         } else {
@@ -472,7 +483,7 @@ public class Parser {
         }
     }
 
-    //@@author A0131560U
+    // @@author A0131560U
     /**
      * Given a specific pattern, extracts all phrases that match the pattern and
      * adds them to keywordSet. Returns args string without the keywords that
@@ -504,55 +515,55 @@ public class Parser {
      * @author darren
      */
 
-	 //@@author A0147609X
-	/**
-	 * splits multi-arguments into a nice ArrayList of strings
-	 * 
-	 * @param params
-	 *            comma-separated parameters
-	 * @param delimiter
-	 *            delimiting character
-	 * @return ArrayList<String> of parameters
-	 * @author darren
-	 */
-	public static ArrayList<String> parseMultipleParameters(String params, char delimiter) {
-		CSVParser parser = new CSVParser(delimiter);
+    // @@author A0147609X
+    /**
+     * splits multi-arguments into a nice ArrayList of strings
+     * 
+     * @param params
+     *            comma-separated parameters
+     * @param delimiter
+     *            delimiting character
+     * @return ArrayList<String> of parameters
+     * @author darren
+     */
+    public static ArrayList<String> parseMultipleParameters(String params, char delimiter) {
+        CSVParser parser = new CSVParser(delimiter);
 
-		try {
-			String[] tokens = parser.parseLine(params);
+        try {
+            String[] tokens = parser.parseLine(params);
 
-			// strip leading and trailing whitespaces
-			for (int i = 0; i < tokens.length; i++) {
-				tokens[i] = tokens[i].trim();
-			}
+            // strip leading and trailing whitespaces
+            for (int i = 0; i < tokens.length; i++) {
+                tokens[i] = tokens[i].trim();
+            }
 
-			return new ArrayList<>(Arrays.asList(tokens));
-		} catch (IOException ioe) {
-			System.out.println(ioe.getMessage());
-		}
+            return new ArrayList<>(Arrays.asList(tokens));
+        } catch (IOException ioe) {
+            System.out.println(ioe.getMessage());
+        }
 
-		return null;
-	}
-	//@@author 
+        return null;
+    }
+    // @@author
 
-	 //@@author A0147609X-unused
-	/**
-	 * checks field names are valid
-	 * 
-	 * @param fieldNames
-	 *            an ArrayList<String> of field names
-	 * @return true if all fields are valid, false otherwise
-	 * @author darren
-	 */
-	private static boolean fieldsAreValid(ArrayList<String> fieldNames) {
-		assert fieldNames != null;
-		for (String fieldName : fieldNames) {
-			try {
-				Field ret = Field.valueOf(fieldName.toUpperCase());
-			} catch (IllegalArgumentException iae) {
-				return false;
-			}
-		}
-		return true;
-	}
+    // @@author A0147609X-unused
+    /**
+     * checks field names are valid
+     * 
+     * @param fieldNames
+     *            an ArrayList<String> of field names
+     * @return true if all fields are valid, false otherwise
+     * @author darren
+     */
+    private static boolean fieldsAreValid(ArrayList<String> fieldNames) {
+        assert fieldNames != null;
+        for (String fieldName : fieldNames) {
+            try {
+                Field ret = Field.valueOf(fieldName.toUpperCase());
+            } catch (IllegalArgumentException iae) {
+                return false;
+            }
+        }
+        return true;
+    }
 }

--- a/src/main/java/seedu/sudowudo/logic/parser/Parser.java
+++ b/src/main/java/seedu/sudowudo/logic/parser/Parser.java
@@ -67,7 +67,7 @@ public class Parser {
     private static final Pattern COMMAND_TAG_SEARCH_FORMAT = Pattern.compile("#([^ ]+)");
     private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter
             .ofPattern("yyyy-MM-dd HH:mm");
-    private static final DateTimeParser dtParser = DateTimeParser.getInstance();
+    private DateTimeParser dtParser = DateTimeParser.getInstance();
     private static Parser instance = new Parser();
 
     private Parser() {
@@ -447,7 +447,7 @@ public class Parser {
         assert !args.isEmpty();
         assert keywordSet != null;
 
-        this.dtParser.parse(args);
+        dtParser.parse(args);
 
         if (dtParser.extractStartDate() != null) {
             keywordSet.add(dtParser.extractStartDate().format(DATE_TIME_FORMATTER));

--- a/src/main/java/seedu/sudowudo/logic/parser/Parser.java
+++ b/src/main/java/seedu/sudowudo/logic/parser/Parser.java
@@ -38,12 +38,12 @@ import seedu.sudowudo.model.item.Item;
  */
 public class Parser {
 
-    private static final String EMPTY_STRING = "";
     public static final String COMMAND_TAG_REGEX = "#(.*)";
     public static final String COMMAND_DESCRIPTION_REGEX = "\"(.*)\"";
     public static final String COMMAND_TAG_PREFIX = "#";
     public static final String COMMAND_DESCRIPTION_PREFIX = "\"";
 
+    private static final String EMPTY_STRING = "";
     /**
      * Used for initial separation of command word and args.
      */
@@ -55,42 +55,19 @@ public class Parser {
 
     // item has description and a string representing time to be processed
     private static final Pattern ITEM_DATA_ARGS_FORMAT = Pattern.compile("(.*)\\\"(.*)\\\"(.*)");
-
     private static final Pattern TASK_DATA_ARGS_FORMAT = Pattern.compile("(.*)\\\"(.*)\\\"");
-
     private static final Pattern ITEM_EDIT_ARGS_FORMAT = Pattern
             .compile("(?<targetIndex>\\d+)\\s+(?<arguments>.*)");
-
     private static final String TASK_NO_DATE_DATA = "nothing";
     private static final Pattern ITEM_INDEX_ARGS_FORMAT = Pattern.compile("(?<targetIndex>.+)");
-
     private static final int COMMAND_DESCRIPTION_FIELD_NUMBER = 2;
     private static final int COMMAND_TYPE_FIELD_NUMBER = 1;
     private static final int COMMAND_TIME_FIELD_NUMBER = 3;
-
     private static final Pattern COMMAND_DESCRIPTION_SEARCH_FORMAT = Pattern.compile("\"([^\"]*)\"");
     private static final Pattern COMMAND_TAG_SEARCH_FORMAT = Pattern.compile("#([^ ]+)");
-
     private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter
             .ofPattern("yyyy-MM-dd HH:mm");
-
-    private final DateTimeParser dtparser = DateTimeParser.getInstance();
-
-    public enum Field {
-        NAME("name"), START_DATE("start_date"), END_DATE("end_date"), START_TIME("start_time"), END_TIME(
-                "end_time"), DATE("date"), TIME("time");
-
-        private String field_name;
-
-        Field(String name) {
-            this.field_name = name;
-        }
-
-        public String getFieldName() {
-            return this.field_name;
-        }
-    }
-
+    private static final DateTimeParser dtParser = DateTimeParser.getInstance();
     private static Parser instance = new Parser();
 
     private Parser() {
@@ -470,12 +447,12 @@ public class Parser {
         assert !args.isEmpty();
         assert keywordSet != null;
 
-        this.dtparser.parse(args);
+        this.dtParser.parse(args);
 
-        if (dtparser.extractStartDate() != null) {
-            keywordSet.add(dtparser.extractStartDate().format(DATE_TIME_FORMATTER));
-            if (dtparser.extractEndDate() != null) {
-                keywordSet.add(dtparser.extractEndDate().format(DATE_TIME_FORMATTER));
+        if (dtParser.extractStartDate() != null) {
+            keywordSet.add(dtParser.extractStartDate().format(DATE_TIME_FORMATTER));
+            if (dtParser.extractEndDate() != null) {
+                keywordSet.add(dtParser.extractEndDate().format(DATE_TIME_FORMATTER));
             }
             return true;
         } else {
@@ -546,24 +523,4 @@ public class Parser {
     }
     // @@author
 
-    // @@author A0147609X-unused
-    /**
-     * checks field names are valid
-     * 
-     * @param fieldNames
-     *            an ArrayList<String> of field names
-     * @return true if all fields are valid, false otherwise
-     * @author darren
-     */
-    private static boolean fieldsAreValid(ArrayList<String> fieldNames) {
-        assert fieldNames != null;
-        for (String fieldName : fieldNames) {
-            try {
-                Field ret = Field.valueOf(fieldName.toUpperCase());
-            } catch (IllegalArgumentException iae) {
-                return false;
-            }
-        }
-        return true;
-    }
 }

--- a/src/test/java/seedu/sudowudo/logic/parser/DateTimeParserTest.java
+++ b/src/test/java/seedu/sudowudo/logic/parser/DateTimeParserTest.java
@@ -20,10 +20,12 @@ import org.junit.Test;
  */
 public class DateTimeParserTest {
 
+    private DateTimeParser parser = DateTimeParser.getInstance();
+    
     @Test
     public void extractExplicitStartDateTimeTest() {
         String input = "16 september 2016 5pm to 17 september 2016 6pm";
-        DateTimeParser parser = new DateTimeParser(input);
+        parser.parse(input);
 
         LocalDateTime start = LocalDateTime.of(LocalDate.of(2016, 9, 16), LocalTime.of(17, 0));
 
@@ -33,7 +35,7 @@ public class DateTimeParserTest {
     @Test
     public void extractImplicitStartDateTimeTest() {
         String input = "2213 fifth january";
-        DateTimeParser parser = new DateTimeParser(input);
+        parser.parse(input);
         
         LocalDateTime start = LocalDateTime.of(LocalDate.of(2016, 1, 5), LocalTime.of(22, 13));
         
@@ -43,7 +45,7 @@ public class DateTimeParserTest {
     @Test
     public void extractExplicitEndDateTimeTest() {
         String input = "16 september 2016 5pm to 17 september 2016 6:30pm";
-        DateTimeParser parser = new DateTimeParser(input);
+        parser.parse(input);
 
         LocalDateTime end = LocalDateTime.of(LocalDate.of(2016, 9, 17), LocalTime.of(18, 30));
 
@@ -53,7 +55,7 @@ public class DateTimeParserTest {
     @Test
     public void extractImplicitEndDateTimeTest() {
         String input = "1800 fifth january till the sixth october at 9:30pm";
-        DateTimeParser parser = new DateTimeParser(input);
+        parser.parse(input);
         
         LocalDateTime end = LocalDateTime.of(LocalDate.of(2016, 10, 6), LocalTime.of(21, 30));
         
@@ -63,7 +65,7 @@ public class DateTimeParserTest {
     @Test
     public void extractMissingEndDateTimeTest() {
         String input = "by 12 november 1996 at 5pm";
-        DateTimeParser parser = new DateTimeParser(input);
+        parser.parse(input);
 
         LocalDateTime deadline = LocalDateTime.of(LocalDate.of(1996, 11, 12), LocalTime.of(17, 0));
 
@@ -111,7 +113,7 @@ public class DateTimeParserTest {
     @Test
     public void extractRecurringEventDetails() {
         String input = "every monday at 9am until 25 december 2016";
-        DateTimeParser parser = new DateTimeParser(input);
+        parser.parse(input);
 
         LocalDateTime recurEndDateTime = LocalDateTime.of(LocalDate.of(2016, 12, 25), LocalTime.of(9, 0));
         assertEquals(true, parser.isRecurring());
@@ -121,7 +123,7 @@ public class DateTimeParserTest {
     @Test
     public void extractNonRecurringEventDetails() {
         String input = "on fifth of november at 5pm";
-        DateTimeParser parser = new DateTimeParser(input);
+        parser.parse(input);
 
         assertEquals(false, parser.isRecurring());
     }

--- a/src/test/java/seedu/sudowudo/testutil/ItemBuilder.java
+++ b/src/test/java/seedu/sudowudo/testutil/ItemBuilder.java
@@ -1,7 +1,5 @@
 package seedu.sudowudo.testutil;
 
-import java.time.LocalDateTime;
-
 import seedu.sudowudo.commons.exceptions.IllegalValueException;
 import seedu.sudowudo.logic.parser.DateTimeParser;
 import seedu.sudowudo.model.item.Description;
@@ -11,38 +9,38 @@ import seedu.sudowudo.model.tag.UniqueTagList;
 public class ItemBuilder {
 
     private TestItem item;
-    
-    public ItemBuilder(){
+    private final DateTimeParser dtparser = DateTimeParser.getInstance();
+
+    public ItemBuilder() {
         this.item = new TestItem();
     }
-    //@@author A0131560U
-    public ItemBuilder withDescription(String description) throws IllegalValueException{
+
+    // @@author A0131560U
+    public ItemBuilder withDescription(String description) throws IllegalValueException {
         this.item.setDescription(new Description(description));
         return this;
     }
-    //@@author A0144750J
-    public ItemBuilder withDates(String startdate) throws IllegalValueException{
-    	DateTimeParser parser = new DateTimeParser(startdate);
-		LocalDateTime startTimeObj = parser.extractStartDate();
-		LocalDateTime endTimeObj = parser.extractStartDate();
-		this.item.setStartDate(startTimeObj);
-		this.item.setEndDate(endTimeObj);
-		return this;
+
+    // @@author A0144750J
+    public ItemBuilder withDates(String startDate) throws IllegalValueException {
+        this.dtparser.parse(startDate);
+        this.item.setStartDate(this.dtparser.extractStartDate());
+        this.item.setEndDate(this.dtparser.extractEndDate());
+        return this;
     }
-    
-    //@@author
-    public ItemBuilder withTags(String... tags) throws IllegalValueException{
-        UniqueTagList replacement = new UniqueTagList(); 
-        for (String tag : tags){
+
+    // @@author
+    public ItemBuilder withTags(String... tags) throws IllegalValueException {
+        UniqueTagList replacement = new UniqueTagList();
+        for (String tag : tags) {
             replacement.add(new Tag(tag));
         }
         this.item.setTags(replacement);
         return this;
     }
 
-    
-    public TestItem build(){
+    public TestItem build() {
         return this.item;
     }
-    
+
 }

--- a/src/test/java/seedu/sudowudo/testutil/ItemBuilder.java
+++ b/src/test/java/seedu/sudowudo/testutil/ItemBuilder.java
@@ -22,8 +22,8 @@ public class ItemBuilder {
     }
 
     // @@author A0144750J
-    public ItemBuilder withDates(String startDate) throws IllegalValueException {
-        this.dtparser.parse(startDate);
+    public ItemBuilder withDates(String datetime) throws IllegalValueException {
+        this.dtparser.parse(datetime);
         this.item.setStartDate(this.dtparser.extractStartDate());
         this.item.setEndDate(this.dtparser.extractEndDate());
         return this;

--- a/src/test/java/seedu/sudowudo/testutil/TypicalTestItems.java
+++ b/src/test/java/seedu/sudowudo/testutil/TypicalTestItems.java
@@ -20,14 +20,14 @@ public class TypicalTestItems {
             always  = new ItemBuilder().withDescription("Always brush teeth").withDates("no date info").withTags("important","priority").build();
             bags    = new ItemBuilder().withDescription("Pack bag with the thing that I always need to bring").withDates("no date info").build();
             cs2103  = new ItemBuilder().withDescription("Finish my CS2103 homework").withDates("from today to next Sunday").withTags("CS2103","homework","important").build();
-            dover   = new ItemBuilder().withDescription("Dover Road").withDates("October 5th next yeat to November 9th next year").build();
+            dover   = new ItemBuilder().withDescription("Dover Road").withDates("October 5th next year to November 9th next year").build();
             eating  = new ItemBuilder().withDescription("eat 1 child").withDates("by Friday").withTags("ohdear","feefifofum").build();
             frolick = new ItemBuilder().withDescription("frolick in the grass").withDates("from tomorrow to Sunday").build();
             grass   = new ItemBuilder().withDescription("You are allergic to grass").withDates("by next week").build();
             //@@author A0144750J
             //Manually added
             help    = new ItemBuilder().withDescription("Read help instructions").withDates("no date info").build();
-            indeed  = new ItemBuilder().withDescription("Indeed this is a test item").withDates("22/10/2016 to december 12").build();
+            indeed  = new ItemBuilder().withDescription("Indeed this is a test item").withDates("today 6pm to 12 december").build();
         } catch (IllegalValueException e) {
             e.printStackTrace();
             assert false : "not possible";


### PR DESCRIPTION
# Changes
1. `DateTimeParser` is now a singleton object.
2. All classes that call upon `DateTimeParser` are adapted to the new pattern.
3. Fixed a typo in`ItemBuilder.withDates`.
4. Change datetime token in `TypicalTestItem.indeed` from formal date to relative date.

Fixes #102 