### PR TITLE
Scroll to an item when it is changed

### DIFF
--- a/src/main/java/seedu/sudowudo/commons/events/ui/ItemChangeEvent.java
+++ b/src/main/java/seedu/sudowudo/commons/events/ui/ItemChangeEvent.java
@@ -5,6 +5,8 @@ import seedu.sudowudo.model.item.ReadOnlyItem;
 
 /**
  * Indicates a request to jump to an item that has changed
+ * 
+ * @@author A0092390E
  */
 public class ItemChangeEvent extends BaseEvent {
 

--- a/src/main/java/seedu/sudowudo/commons/events/ui/ItemChangeEvent.java
+++ b/src/main/java/seedu/sudowudo/commons/events/ui/ItemChangeEvent.java
@@ -1,0 +1,26 @@
+package seedu.sudowudo.commons.events.ui;
+
+import seedu.sudowudo.commons.events.BaseEvent;
+import seedu.sudowudo.model.item.ReadOnlyItem;
+
+/**
+ * Indicates a request to jump to an item that has changed
+ */
+public class ItemChangeEvent extends BaseEvent {
+
+    public final ReadOnlyItem item;
+
+    public ItemChangeEvent(ReadOnlyItem item) {
+        this.item = item;
+    }
+
+    @Override
+    public String toString() {
+        return this.getClass().getSimpleName();
+    }
+    
+	public ReadOnlyItem getItem() {
+		return this.item;
+	}
+
+}

--- a/src/main/java/seedu/sudowudo/ui/CommandBox.java
+++ b/src/main/java/seedu/sudowudo/ui/CommandBox.java
@@ -10,9 +10,11 @@ import javafx.scene.control.SplitPane;
 import javafx.scene.control.TextField;
 import javafx.scene.layout.AnchorPane;
 import javafx.stage.Stage;
+import seedu.sudowudo.commons.core.EventsCenter;
 import seedu.sudowudo.commons.core.LogsCenter;
 import seedu.sudowudo.commons.events.ui.CycleCommandHistoryEvent;
 import seedu.sudowudo.commons.events.ui.IncorrectCommandAttemptedEvent;
+import seedu.sudowudo.commons.events.ui.ItemChangeEvent;
 import seedu.sudowudo.commons.util.FxViewUtil;
 import seedu.sudowudo.logic.Logic;
 import seedu.sudowudo.logic.commands.CommandResult;
@@ -87,6 +89,8 @@ public class CommandBox extends UiPart {
         mostRecentResult = logic.execute(previousCommandTest);
 		setStyleToIndicateCorrectCommand(mostRecentResult.getClear());
         resultDisplay.postMessage(mostRecentResult.feedbackToUser);
+		EventsCenter.getInstance().post(new ItemChangeEvent(mostRecentResult.getItem()));
+
         logger.info("Result: " + mostRecentResult.feedbackToUser);
     }
 

--- a/src/main/java/seedu/sudowudo/ui/ItemListPanel.java
+++ b/src/main/java/seedu/sudowudo/ui/ItemListPanel.java
@@ -2,6 +2,8 @@ package seedu.sudowudo.ui;
 
 import java.util.logging.Logger;
 
+import com.google.common.eventbus.Subscribe;
+
 import javafx.application.Platform;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
@@ -12,7 +14,9 @@ import javafx.scene.control.SplitPane;
 import javafx.scene.layout.AnchorPane;
 import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
+import seedu.sudowudo.commons.core.EventsCenter;
 import seedu.sudowudo.commons.core.LogsCenter;
+import seedu.sudowudo.commons.events.ui.ItemChangeEvent;
 import seedu.sudowudo.commons.events.ui.ItemPanelSelectionChangedEvent;
 import seedu.sudowudo.model.item.ReadOnlyItem;
 
@@ -47,11 +51,20 @@ public class ItemListPanel extends UiPart {
         this.placeHolderPane = pane;
     }
 
+	@Subscribe
+	public void itemChangeEvent(ItemChangeEvent e) {
+		ReadOnlyItem toScrollTo = e.getItem();
+		if (toScrollTo != null) {
+			itemListView.scrollTo(toScrollTo);
+		}
+	}
+
     public static ItemListPanel load(Stage primaryStage, AnchorPane itemListPlaceholder,
                                        ObservableList<ReadOnlyItem> itemList) {
         ItemListPanel itemListPanel =
                 UiPartLoader.loadUiPart(primaryStage, itemListPlaceholder, new ItemListPanel());
         itemListPanel.configure(itemList);
+		EventsCenter.getInstance().registerHandler(itemListPanel);
         return itemListPanel;
     }
 

--- a/src/main/java/seedu/sudowudo/ui/ItemListPanel.java
+++ b/src/main/java/seedu/sudowudo/ui/ItemListPanel.java
@@ -51,6 +51,11 @@ public class ItemListPanel extends UiPart {
         this.placeHolderPane = pane;
     }
 
+	/*
+	 * Subscribe to item change events and scroll to them
+	 * 
+	 * @@author A0092390E
+	 */
 	@Subscribe
 	public void itemChangeEvent(ItemChangeEvent e) {
 		ReadOnlyItem toScrollTo = e.getItem();
@@ -58,6 +63,7 @@ public class ItemListPanel extends UiPart {
 			itemListView.scrollTo(toScrollTo);
 		}
 	}
+	// @@author
 
     public static ItemListPanel load(Stage primaryStage, AnchorPane itemListPlaceholder,
                                        ObservableList<ReadOnlyItem> itemList) {


### PR DESCRIPTION
Exactly what it says. Any time a CommandResult contains an item, we try to scroll to that item in ItemListView.

Also allows you to trigger that behaviour by posting the ItemChangedEvent event.

@craaaa take a look at CommandBox line 92 for how to post the event.