### PR TITLE
Improve DateTimeParser abstraction & unit tests

### DIFF
--- a/src/main/java/seedu/sudowudo/commons/util/ListUtil.java
+++ b/src/main/java/seedu/sudowudo/commons/util/ListUtil.java
@@ -13,32 +13,34 @@ public class ListUtil {
 
     private static ListUtil instance = new ListUtil();
 
-    //@@author A0131560U
-    private ListUtil(){};
-    
-    public static ListUtil getInstance(){
+    // @@author A0131560U
+    private ListUtil() {
+    };
+
+    public static ListUtil getInstance() {
         return instance;
     }
 
-    public void updateFilteredItemList(FilteredList<Item> filteredItems, Set<String> keywords, Predicate defaultPredicate){
-        updateFilteredItemList(filteredItems, new QualifierPredicate(new KeywordQualifier(keywords)).and(defaultPredicate));
+    public void updateFilteredItemList(FilteredList<Item> filteredItems, Set<String> keywords,
+            Predicate defaultPredicate) {
+        updateFilteredItemList(filteredItems,
+                new QualifierPredicate(new KeywordQualifier(keywords)).and(defaultPredicate));
 
     }
-    
-    public Predicate setDefaultPredicate(String taskType){
+
+    public Predicate setDefaultPredicate(String taskType) {
         return new QualifierPredicate(new TypeQualifier(taskType));
     }
-    
+
     // @@author A0092390E
     private void updateFilteredItemList(FilteredList<Item> filteredItems, Predicate pred) {
         filteredItems.setPredicate(pred);
     }
-    
-    //@@author
-    public void updateFilteredItemList(FilteredList<Item> filteredItems, Set<String> keywords) {
-        updateFilteredItemList(filteredItems, new QualifierPredicate(new KeywordQualifier(keywords)));        
-    }
 
+    // @@author
+    public void updateFilteredItemList(FilteredList<Item> filteredItems, Set<String> keywords) {
+        updateFilteredItemList(filteredItems, new QualifierPredicate(new KeywordQualifier(keywords)));
+    }
 
     private class QualifierPredicate implements Predicate<ReadOnlyItem> {
 
@@ -67,9 +69,11 @@ public class ListUtil {
         String toString();
     }
 
-    //@@author A0131560U
+    // @@author A0131560U
     /**
-     * A Qualifier class that particularly checks for Item Type (e.g. Task, Event, Done).
+     * A Qualifier class that particularly checks for Item Type (e.g. Task,
+     * Event, Done).
+     * 
      * @author craa
      *
      */
@@ -93,9 +97,10 @@ public class ListUtil {
 
     }
 
-    //@@author A0131560U
+    // @@author A0131560U
     /**
      * A Qualifier class that particularly checks a set of keywords.
+     * 
      * @author craa
      *
      */
@@ -125,7 +130,9 @@ public class ListUtil {
 
     // @@author A0092390E-idea
     /**
-     * An anonymous class that holds a keyword. This keyword is used to search against items.
+     * An anonymous class that holds a keyword. This keyword is used to search
+     * against items.
+     * 
      * @author craa
      *
      */
@@ -136,9 +143,11 @@ public class ListUtil {
             keyword = _keyword;
         }
 
-        //@@author A0131560U
+        // @@author A0131560U
         /**
-         * Returns true if the item matches the keyword in this instance of Keyword.
+         * Returns true if the item matches the keyword in this instance of
+         * Keyword.
+         * 
          * @param item
          * @return
          */
@@ -154,34 +163,39 @@ public class ListUtil {
 
         /**
          * Checks if the item's start or end date matches the keyword.
+         * 
          * @param item
          * @return
          */
         private boolean matchesDates(ReadOnlyItem item) {
-            DateTimeParser parseDate = new DateTimeParser(keyword);
+            DateTimeParser parser = DateTimeParser.getInstance();
+            parser.parse(keyword);
+
             return ((item.getStartDate() != null
-                    && DateTimeParser.isSameDay(item.getStartDate(), parseDate.extractStartDate())
+                    && DateTimeParser.isSameDay(item.getStartDate(), parser.extractStartDate())
                     || (item.getEndDate() != null
-                            && DateTimeParser.isSameDay(item.getEndDate(), parseDate.extractStartDate()))));
+                            && DateTimeParser.isSameDay(item.getEndDate(), parser.extractStartDate()))));
         }
 
         /**
          * Checks if the item's tags (or types, if the tag string actually
          * aliases to a type meta-tag) match the keyword.
+         * 
          * @param item
          * @return
          */
         private boolean matchesTags(ReadOnlyItem item) {
             keyword = keyword.replaceFirst(Parser.COMMAND_TAG_PREFIX, "");
-            if (isKeywordType()){
+            if (isKeywordType()) {
                 return item.is(keyword);
             }
 
-            return StringUtil.containsIgnoreCase(item.getTags().listTags(),keyword);
+            return StringUtil.containsIgnoreCase(item.getTags().listTags(), keyword);
         }
 
         /**
          * Checks if the item's description matches the keyword
+         * 
          * @param item
          * @return
          */
@@ -189,8 +203,8 @@ public class ListUtil {
             return StringUtil.containsIgnoreCase(item.getDescription().getFullDescription(),
                     keyword.replace(Parser.COMMAND_DESCRIPTION_PREFIX, ""));
         }
-        
-        private boolean isKeywordType(){
+
+        private boolean isKeywordType() {
             return Parser.isValidType(keyword);
         }
     }

--- a/src/main/java/seedu/sudowudo/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/sudowudo/logic/commands/AddCommand.java
@@ -19,27 +19,25 @@ import seedu.sudowudo.model.tag.UniqueTagList.DuplicateTagException;
 
 public class AddCommand extends Command {
 
-    private static final String EMPTY_STRING = "";
-
     public static final String COMMAND_WORD = "add";
-
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Adds a task to the to-do list. "
             + "Parameters: \"EVENT_NAME\" from START_TIME to END_TIME on DATE #TAGS"
             + "Example: " + COMMAND_WORD
             + "\"Be awesome\" from 1300 to 2359 on 07/10/2016 #cool #nice";
-
     public static final String MESSAGE_SUCCESS = "New %1$s added: %2$s";
     public static final String MESSAGE_SUCCESS_TIME_NULL = "START or END time not found but new %1$s added!";
     public static final String MESSAGE_DUPLICATE_ITEM = "This task already exists in the to-do list";
     public static final String MESSAGE_UNDO_SUCCESS = "Undo add task: %1$s";
+
     private static final String DEFAULT_ITEM_NAME = "BLOCK";
+    private static final String EMPTY_STRING = "";
+    private static final DateTimeParser dtParser = DateTimeParser.getInstance();
 
     private final Item toAdd;
     private Item toUndoAdd;
     private boolean hasTimeString = false;
     
-    private final DateTimeParser dtparser = DateTimeParser.getInstance();
 
     /**
      * Constructor using raw strings
@@ -88,11 +86,11 @@ public class AddCommand extends Command {
     }
 
     private LocalDateTime setEndDateTime(String timeStr) {
-        return this.dtparser.parse(timeStr).extractEndDate();
+        return dtParser.parse(timeStr).extractEndDate();
     }
 
     private LocalDateTime setStartDateTime(String timeStr) {
-        return this.dtparser.parse(timeStr).extractStartDate();
+        return dtParser.parse(timeStr).extractStartDate();
     }
 
     private Description setDescription(String descriptionStr)

--- a/src/main/java/seedu/sudowudo/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/sudowudo/logic/commands/AddCommand.java
@@ -38,6 +38,8 @@ public class AddCommand extends Command {
     private final Item toAdd;
     private Item toUndoAdd;
     private boolean hasTimeString = false;
+    
+    private final DateTimeParser dtparser = DateTimeParser.getInstance();
 
     /**
      * Constructor using raw strings
@@ -86,15 +88,11 @@ public class AddCommand extends Command {
     }
 
     private LocalDateTime setEndDateTime(String timeStr) {
-        DateTimeParser parser = new DateTimeParser(timeStr);
-        LocalDateTime endTimeObj = parser.extractEndDate();
-        return endTimeObj;
+        return this.dtparser.parse(timeStr).extractEndDate();
     }
 
     private LocalDateTime setStartDateTime(String timeStr) {
-        DateTimeParser parser = new DateTimeParser(timeStr);
-        LocalDateTime startTimeObj = parser.extractStartDate();
-        return startTimeObj;
+        return this.dtparser.parse(timeStr).extractStartDate();
     }
 
     private Description setDescription(String descriptionStr)

--- a/src/main/java/seedu/sudowudo/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/sudowudo/logic/commands/AddCommand.java
@@ -32,7 +32,7 @@ public class AddCommand extends Command {
 
     private static final String DEFAULT_ITEM_NAME = "BLOCK";
     private static final String EMPTY_STRING = "";
-    private static final DateTimeParser dtParser = DateTimeParser.getInstance();
+    private DateTimeParser dtParser = DateTimeParser.getInstance();
 
     private final Item toAdd;
     private Item toUndoAdd;

--- a/src/main/java/seedu/sudowudo/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/sudowudo/logic/commands/EditCommand.java
@@ -18,7 +18,6 @@ import seedu.sudowudo.model.tag.UniqueTagList;
 public class EditCommand extends Command {
 
     public static final String COMMAND_WORD = "edit";
-
     public static final String MESSAGE_USAGE = COMMAND_WORD + "... edit ..." + ": Edits an existing item.\n"
             + "Syntax: edit CONTEXT_ID FIELD:NEW_DETAIL\n" + "Example: " + COMMAND_WORD
             + " 2 start:tomorrow 6pm";
@@ -29,14 +28,13 @@ public class EditCommand extends Command {
     public static final String MESSAGE_UNDO_SUCCESS = "Undo edit task: %1$s";
     public static final String MESSAGE_UNDO_FAILURE = "Failed to undo edit task: %1$s";
 
-    public static final String[] ALLOWED_FIELDS = { "desc", "description", "start", "end", "by", "period" };
+    public final int targetIndex;
+
+    private static final DateTimeParser dtParser = DateTimeParser.getInstance();
 
     private Item itemToModify;
     private Item previousTemplate;
-    public final int targetIndex;
     private ArrayList<String[]> editFields;
-
-    private final DateTimeParser dtparser = DateTimeParser.getInstance();
 
     // @@author A0092390E
     /**
@@ -93,16 +91,16 @@ public class EditCommand extends Command {
                 model.setItemDesc(itemToModify, newFieldDetail);
                 break;
             case "start":
-                model.setItemStart(itemToModify, this.dtparser.parse(newFieldDetail).extractStartDate());
+                model.setItemStart(itemToModify, dtParser.parse(newFieldDetail).extractStartDate());
                 break;
             case "end":
             case "by":
-                model.setItemEnd(itemToModify, this.dtparser.parse(newFieldDetail).extractStartDate());
+                model.setItemEnd(itemToModify, dtParser.parse(newFieldDetail).extractStartDate());
                 break;
             case "period":
-                this.dtparser.parse(newFieldDetail);
-                model.setItemStart(itemToModify, this.dtparser.extractStartDate());
-                model.setItemEnd(itemToModify, this.dtparser.extractEndDate());
+                dtParser.parse(newFieldDetail);
+                model.setItemStart(itemToModify, dtParser.extractStartDate());
+                model.setItemEnd(itemToModify, dtParser.extractEndDate());
                 break;
             default:
                 // field names not valid

--- a/src/main/java/seedu/sudowudo/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/sudowudo/logic/commands/EditCommand.java
@@ -30,7 +30,7 @@ public class EditCommand extends Command {
 
     public final int targetIndex;
 
-    private static final DateTimeParser dtParser = DateTimeParser.getInstance();
+    private DateTimeParser dtParser = DateTimeParser.getInstance();
 
     private Item itemToModify;
     private Item previousTemplate;

--- a/src/main/java/seedu/sudowudo/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/sudowudo/logic/commands/EditCommand.java
@@ -19,10 +19,9 @@ public class EditCommand extends Command {
 
     public static final String COMMAND_WORD = "edit";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + "... edit ..."
-            + ": Edits an existing item.\n"
-            + "Syntax: edit CONTEXT_ID FIELD:NEW_DETAIL\n" + "Example: "
-            + COMMAND_WORD + " 2 start:tomorrow 6pm";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + "... edit ..." + ": Edits an existing item.\n"
+            + "Syntax: edit CONTEXT_ID FIELD:NEW_DETAIL\n" + "Example: " + COMMAND_WORD
+            + " 2 start:tomorrow 6pm";
 
     public static final String MESSAGE_SUCCESS = "Successfully edited: %1$s";
     public static final String MESSAGE_DUPLICATE_ITEM = "This task already exists in the to-do list";
@@ -30,15 +29,16 @@ public class EditCommand extends Command {
     public static final String MESSAGE_UNDO_SUCCESS = "Undo edit task: %1$s";
     public static final String MESSAGE_UNDO_FAILURE = "Failed to undo edit task: %1$s";
 
-    public static final String[] ALLOWED_FIELDS = { "desc", "description",
-            "start", "end", "by", "period" };
+    public static final String[] ALLOWED_FIELDS = { "desc", "description", "start", "end", "by", "period" };
 
     private Item itemToModify;
     private Item previousTemplate;
     public final int targetIndex;
     private ArrayList<String[]> editFields;
 
-    //@@author A0092390E
+    private final DateTimeParser dtparser = DateTimeParser.getInstance();
+
+    // @@author A0092390E
     /**
      * Constructor using raw strings
      * 
@@ -49,8 +49,7 @@ public class EditCommand extends Command {
      *            which is a field:value pair
      * @throws IllegalValueException
      */
-    public EditCommand(Integer index, ArrayList<String> arguments)
-            throws IllegalValueException {
+    public EditCommand(Integer index, ArrayList<String> arguments) throws IllegalValueException {
         this.targetIndex = index;
         assert arguments.size() != 0;
 
@@ -59,12 +58,11 @@ public class EditCommand extends Command {
             editFields.add(argument.split(":", 2));
         }
 
-        previousTemplate = new Item(new Description("dummy"), null, null,
-                new UniqueTagList());
+        previousTemplate = new Item(new Description("dummy"), null, null, new UniqueTagList());
     }
-    //@@author
+    // @@author
 
-    //@@author A0147609X
+    // @@author A0147609X
     /**
      * Executes the edit command.
      * 
@@ -77,8 +75,7 @@ public class EditCommand extends Command {
         if (lastShownList.size() < targetIndex) {
             indicateAttemptToExecuteIncorrectCommand();
             hasUndo = false;
-            return new CommandResult(
-                    Messages.MESSAGE_INVALID_ITEM_DISPLAYED_INDEX);
+            return new CommandResult(Messages.MESSAGE_INVALID_ITEM_DISPLAYED_INDEX);
         }
 
         itemToModify = lastShownList.get(this.targetIndex - 1);
@@ -86,38 +83,37 @@ public class EditCommand extends Command {
         // deep copy the item to a template for undo
         previousTemplate = itemToModify.deepCopy();
 
-        for (String[] editField : editFields) {
-            switch (editField[0]) {
-                case "desc":
-                case "description":
-                    model.setItemDesc(itemToModify, editField[1]);
-                    break;
-                case "start":
-                    model.setItemStart(itemToModify,
-                            new DateTimeParser(editField[1])
-                                    .extractStartDate());
-                    break;
-                case "end":
-                case "by":
-                    model.setItemEnd(itemToModify,
-                            new DateTimeParser(editField[1]).extractStartDate());
-                    break;
-                case "period":
-                    DateTimeParser parser = new DateTimeParser(editField[1]);
-                    model.setItemStart(itemToModify, parser.extractStartDate());
-                    model.setItemEnd(itemToModify, parser.extractEndDate());
-                    break;
-                default:
-                    // field names not valid
-                    return new CommandResult(MESSAGE_INVALID_FIELD);
+        for (String[] editStruct : editFields) {
+            String fieldToEdit = editStruct[0];
+            String newFieldDetail = editStruct[1];
+
+            switch (fieldToEdit) {
+            case "desc":
+            case "description":
+                model.setItemDesc(itemToModify, newFieldDetail);
+                break;
+            case "start":
+                model.setItemStart(itemToModify, this.dtparser.parse(newFieldDetail).extractStartDate());
+                break;
+            case "end":
+            case "by":
+                model.setItemEnd(itemToModify, this.dtparser.parse(newFieldDetail).extractStartDate());
+                break;
+            case "period":
+                this.dtparser.parse(newFieldDetail);
+                model.setItemStart(itemToModify, this.dtparser.extractStartDate());
+                model.setItemEnd(itemToModify, this.dtparser.extractEndDate());
+                break;
+            default:
+                // field names not valid
+                return new CommandResult(MESSAGE_INVALID_FIELD);
             }
         }
         hasUndo = true;
-        return new CommandResult(String.format(MESSAGE_SUCCESS, itemToModify),
-                itemToModify);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, itemToModify), itemToModify);
 
     }
-    //@@author
+    // @@author
 
     /**
      * @@author A0144750J
@@ -126,15 +122,12 @@ public class EditCommand extends Command {
     public CommandResult undo() {
         // deep copy the item to a template for undo
 
-        model.setItemDesc(itemToModify,
-                previousTemplate.getDescription().getFullDescription());
+        model.setItemDesc(itemToModify, previousTemplate.getDescription().getFullDescription());
         model.setItemStart(itemToModify, previousTemplate.getStartDate());
         model.setItemEnd(itemToModify, previousTemplate.getEndDate());
         itemToModify.setIsDone(previousTemplate.getIsDone());
         itemToModify.setTags(previousTemplate.getTags());
-        return new CommandResult(
-                String.format(MESSAGE_UNDO_SUCCESS, itemToModify),
-                itemToModify);
+        return new CommandResult(String.format(MESSAGE_UNDO_SUCCESS, itemToModify), itemToModify);
     }
 
 }

--- a/src/main/java/seedu/sudowudo/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/sudowudo/logic/parser/DateTimeParser.java
@@ -64,14 +64,13 @@ public class DateTimeParser {
     public static final DateTimeFormatter SHORT_DAYOFWEEK = DateTimeFormatter
             .ofPattern("EEE");
 
-    public static DateTimeParser dtparser = new DateTimeParser();
+    public static DateTimeParser INSTANCE = new DateTimeParser();
     
     public static DateTimeParser getInstance() {
-        return dtparser;
+        return INSTANCE;
     }
     
-    public DateTimeParser() {
-    }
+    private DateTimeParser() {}
     
     /**
      * Uses the DateTimeParser service to parse a string containing possible

--- a/src/main/java/seedu/sudowudo/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/sudowudo/logic/parser/DateTimeParser.java
@@ -7,6 +7,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalAdjusters;
 import java.util.Date;
 import java.util.List;
 
@@ -187,8 +188,24 @@ public class DateTimeParser {
      *         time
      * @author darren
      */
-    private static boolean isWithinTwoWeeks(LocalDateTime ldt) {
+    public static boolean isWithinTwoWeeks(LocalDateTime ldt) {
         return computeDaysTo(ldt) < 14 && computeDaysTo(ldt) > -14;
+    }
+
+    /**
+     * Check if the given java.time.LocalDateTime object is within the same year
+     * as the local system time.
+     * 
+     * @param ldt
+     * @return true if the LocalDateTime is within the same year as local system
+     *         time
+     * @author darren
+     */
+    public static boolean isWithinThisYear(LocalDateTime ldt) {
+        LocalDate currentDate = ldt.toLocalDate();
+        LocalDate firstDayOfNextYear = LocalDate.now().with(TemporalAdjusters.firstDayOfNextYear());
+        LocalDate lastDayOfLastYear = LocalDate.now().with(TemporalAdjusters.firstDayOfYear()).minusDays(1);
+        return currentDate.isBefore(firstDayOfNextYear) && currentDate.isAfter(lastDayOfLastYear);
     }
 
     /**
@@ -271,11 +288,11 @@ public class DateTimeParser {
 
         // explicit date; no relative prefix
         String prettyDate;
-        if (computeDaysTo(ldt) < 365) {
-            // same year in start and end datetimes
+        if (isWithinThisYear(ldt)) {
+            // LDT is in current year
             prettyDate = ldt.toLocalDate().format(ABRIDGED_DATE_FORMAT);
         } else {
-            // different years in start and end datetimes
+            // LDT is in another year
             prettyDate = ldt.toLocalDate().format(EXPLICIT_DATE_FORMAT);
         }
         return extractShortDayOfWeek(ldt) + SINGLE_WHITESPACE + prettyDate + PRETTY_COMMA_DELIMITER

--- a/src/main/java/seedu/sudowudo/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/sudowudo/logic/parser/DateTimeParser.java
@@ -16,7 +16,8 @@ import org.ocpsoft.prettytime.nlp.parse.DateGroup;
 
 //@@author A0147609X
 /**
- * For parsing dates and times in Sudowudo command input
+ * For parsing dates and times in Sudowudo command input.
+ * Singleton pattern!
  * 
  * @author darren
  */
@@ -63,15 +64,30 @@ public class DateTimeParser {
     public static final DateTimeFormatter SHORT_DAYOFWEEK = DateTimeFormatter
             .ofPattern("EEE");
 
-    public DateTimeParser(String input) {
+    public static DateTimeParser dtparser = new DateTimeParser();
+    
+    public static DateTimeParser getInstance() {
+        return dtparser;
+    }
+    
+    public DateTimeParser() {
+    }
+    
+    /**
+     * Uses the DateTimeParser service to parse a string containing possible
+     * datetime tokens (in natural language).
+     * 
+     * @param input
+     */
+    public void parse(String input) {
         assert input != null;
-        assert input.isEmpty() != true;
 
         this.datetime = input;
 
         // perform parsing
         this.dategroups = DateTimeParser.parser.parseSyntax(input);
         this.dates = DateTimeParser.parser.parse(input);
+        
     }
 
     public LocalDateTime extractStartDate() {

--- a/src/main/java/seedu/sudowudo/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/sudowudo/logic/parser/DateTimeParser.java
@@ -35,8 +35,8 @@ public class DateTimeParser {
     public static final String PRETTY_TO_DELIMITER = SINGLE_WHITESPACE + "-" + SINGLE_WHITESPACE;
 
     // DateTime formatting patterns
-    public static final DateTimeFormatter ABRIDGED_DATE_FORMAT = DateTimeFormatter.ofPattern("dd MMM");
-    public static final DateTimeFormatter EXPLICIT_DATE_FORMAT = DateTimeFormatter.ofPattern("dd MMM yyyy");
+    public static final DateTimeFormatter ABRIDGED_DATE_FORMAT = DateTimeFormatter.ofPattern("d MMM");
+    public static final DateTimeFormatter EXPLICIT_DATE_FORMAT = DateTimeFormatter.ofPattern("d MMM yyyy");
     public static final DateTimeFormatter TWELVE_HOUR_TIME = DateTimeFormatter.ofPattern("h:mma");
     public static final DateTimeFormatter LONG_DAYOFWEEK = DateTimeFormatter.ofPattern("EEEE");
     public static final DateTimeFormatter SHORT_DAYOFWEEK = DateTimeFormatter.ofPattern("EEE");

--- a/src/main/java/seedu/sudowudo/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/sudowudo/logic/parser/DateTimeParser.java
@@ -78,7 +78,7 @@ public class DateTimeParser {
      * 
      * @param input
      */
-    public void parse(String input) {
+    public DateTimeParser parse(String input) {
         assert input != null;
 
         this.datetime = input;
@@ -87,6 +87,7 @@ public class DateTimeParser {
         this.dategroups = DateTimeParser.parser.parseSyntax(input);
         this.dates = DateTimeParser.parser.parse(input);
         
+        return this;
     }
 
     public LocalDateTime extractStartDate() {

--- a/src/main/java/seedu/sudowudo/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/sudowudo/logic/parser/DateTimeParser.java
@@ -410,10 +410,6 @@ public class DateTimeParser {
         return ChronoUnit.DAYS.between(LocalDate.now(), ldt.toLocalDate());
     }
 
-    public DateGroup getDateGroup(int index) {
-        return this.dategroups.get(index);
-    }
-
     public String getDateTime() {
         return this.datetime;
     }

--- a/src/main/java/seedu/sudowudo/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/sudowudo/logic/parser/DateTimeParser.java
@@ -16,8 +16,7 @@ import org.ocpsoft.prettytime.nlp.parse.DateGroup;
 
 //@@author A0147609X
 /**
- * For parsing dates and times in Sudowudo command input.
- * Singleton pattern!
+ * For parsing dates and times in Sudowudo command input. Singleton pattern!
  * 
  * @author darren
  */
@@ -31,20 +30,14 @@ public class DateTimeParser {
     public static final String NEXT_WEEK_REF = "Next" + SINGLE_WHITESPACE;
     public static final String THIS_WEEK_REF = "This" + SINGLE_WHITESPACE;
     public static final String PRETTY_COMMA_DELIMITER = "," + SINGLE_WHITESPACE;
-    public static final String PRETTY_TO_DELIMITER = SINGLE_WHITESPACE + "-"
-            + SINGLE_WHITESPACE;
+    public static final String PRETTY_TO_DELIMITER = SINGLE_WHITESPACE + "-" + SINGLE_WHITESPACE;
 
     // DateTime formatting patterns
-    public static final DateTimeFormatter ABRIDGED_DATE_FORMAT = DateTimeFormatter
-            .ofPattern("dd MMM");
-    public static final DateTimeFormatter EXPLICIT_DATE_FORMAT = DateTimeFormatter
-            .ofPattern("dd MMM yyyy");
-    public static final DateTimeFormatter TWELVE_HOUR_TIME = DateTimeFormatter
-            .ofPattern("h:mma");
-    public static final DateTimeFormatter LONG_DAYOFWEEK = DateTimeFormatter
-            .ofPattern("EEEE");
-    public static final DateTimeFormatter SHORT_DAYOFWEEK = DateTimeFormatter
-            .ofPattern("EEE");
+    public static final DateTimeFormatter ABRIDGED_DATE_FORMAT = DateTimeFormatter.ofPattern("dd MMM");
+    public static final DateTimeFormatter EXPLICIT_DATE_FORMAT = DateTimeFormatter.ofPattern("dd MMM yyyy");
+    public static final DateTimeFormatter TWELVE_HOUR_TIME = DateTimeFormatter.ofPattern("h:mma");
+    public static final DateTimeFormatter LONG_DAYOFWEEK = DateTimeFormatter.ofPattern("EEEE");
+    public static final DateTimeFormatter SHORT_DAYOFWEEK = DateTimeFormatter.ofPattern("EEE");
 
     public static DateTimeParser instance = new DateTimeParser();
 
@@ -65,13 +58,13 @@ public class DateTimeParser {
     private List<DateGroup> dategroups;
     private List<Date> dates;
 
-    private DateTimeParser() {}
-    
+    private DateTimeParser() {
+    }
+
     public static DateTimeParser getInstance() {
         return instance;
     }
-    
-    
+
     /**
      * Uses the DateTimeParser service to parse a string containing possible
      * datetime tokens (in natural language).
@@ -86,7 +79,7 @@ public class DateTimeParser {
         // perform parsing
         this.dategroups = DateTimeParser.parser.parseSyntax(input);
         this.dates = DateTimeParser.parser.parse(input);
-        
+
         return this;
     }
 
@@ -115,8 +108,7 @@ public class DateTimeParser {
     }
 
     public LocalDateTime getRecurEnd() {
-        return changeDateToLocalDateTime(
-                this.dategroups.get(FIRST_DATETIME_TOKEN).getRecursUntil());
+        return changeDateToLocalDateTime(this.dategroups.get(FIRST_DATETIME_TOKEN).getRecursUntil());
     }
 
     /**
@@ -128,8 +120,7 @@ public class DateTimeParser {
      * @return
      * @author darren
      */
-    public static String extractPrettyItemCardDateTime(LocalDateTime start,
-            LocalDateTime end) {
+    public static String extractPrettyItemCardDateTime(LocalDateTime start, LocalDateTime end) {
         if (start == null && end == null) {
             return EMPTY_STRING;
         }
@@ -144,13 +135,11 @@ public class DateTimeParser {
 
         // is an event with a definite start and end datetime
         if (isSameDay(start, end)) {
-            return extractPrettyDateTime(start) + PRETTY_TO_DELIMITER
-                    + extractTwelveHourTime(end);
+            return extractPrettyDateTime(start) + PRETTY_TO_DELIMITER + extractTwelveHourTime(end);
         }
 
         // not same day
-        return extractPrettyDateTime(start) + PRETTY_TO_DELIMITER
-                + extractPrettyDateTime(end);
+        return extractPrettyDateTime(start) + PRETTY_TO_DELIMITER + extractPrettyDateTime(end);
     }
 
     /**
@@ -187,6 +176,19 @@ public class DateTimeParser {
      */
     public static boolean isTomorrow(LocalDateTime ldt) {
         return isSameDay(ldt, LocalDateTime.now().plusDays(1L));
+    }
+
+    /**
+     * Check if the given java.time.LocalDateTime object is within two weeks of
+     * the local system time
+     * 
+     * @param ldt
+     * @return true if the LocalDateTime is within two weeks of local system
+     *         time
+     * @author darren
+     */
+    private static boolean isWithinTwoWeeks(LocalDateTime ldt) {
+        return computeDaysTo(ldt) < 14 && computeDaysTo(ldt) > -14;
     }
 
     /**
@@ -253,20 +255,18 @@ public class DateTimeParser {
     public static String extractPrettyDateTime(LocalDateTime ldt) {
         // special case for today/tomorrow relative to local system time
         if (isToday(ldt)) {
-            return TODAY_DATE_REF + PRETTY_COMMA_DELIMITER
-                    + extractTwelveHourTime(ldt);
+            return TODAY_DATE_REF + PRETTY_COMMA_DELIMITER + extractTwelveHourTime(ldt);
         }
 
         if (isTomorrow(ldt)) {
-            return TOMORROW_DATE_REF + PRETTY_COMMA_DELIMITER
-                    + extractTwelveHourTime(ldt);
+            return TOMORROW_DATE_REF + PRETTY_COMMA_DELIMITER + extractTwelveHourTime(ldt);
         }
 
         // add relative prefix (this/next <day of week>) if applicable
-        if (computeDaysTo(ldt) < 14 && computeDaysTo(ldt) > -14) {
+        if (isWithinTwoWeeks(ldt)) {
             // is within the past/next two weeks
-            return makeRelativePrefix(ldt) + extractLongDayOfWeek(ldt)
-                    + PRETTY_COMMA_DELIMITER + extractTwelveHourTime(ldt);
+            return makeRelativePrefix(ldt) + extractLongDayOfWeek(ldt) + PRETTY_COMMA_DELIMITER
+                    + extractTwelveHourTime(ldt);
         }
 
         // explicit date; no relative prefix
@@ -278,8 +278,8 @@ public class DateTimeParser {
             // different years in start and end datetimes
             prettyDate = ldt.toLocalDate().format(EXPLICIT_DATE_FORMAT);
         }
-        return extractShortDayOfWeek(ldt) + SINGLE_WHITESPACE + prettyDate
-                + PRETTY_COMMA_DELIMITER + extractTwelveHourTime(ldt);
+        return extractShortDayOfWeek(ldt) + SINGLE_WHITESPACE + prettyDate + PRETTY_COMMA_DELIMITER
+                + extractTwelveHourTime(ldt);
     }
 
     /**
@@ -304,8 +304,7 @@ public class DateTimeParser {
      * @return day-of-week
      * @author darren
      */
-    private static String extractDayOfWeek(LocalDateTime ldt,
-            boolean isLongFormat) {
+    private static String extractDayOfWeek(LocalDateTime ldt, boolean isLongFormat) {
         if (isLongFormat) {
             return ldt.toLocalDate().format(LONG_DAYOFWEEK);
         }
@@ -361,5 +360,5 @@ public class DateTimeParser {
     public String getDateTime() {
         return this.datetime;
     }
-    
+
 }

--- a/src/main/java/seedu/sudowudo/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/sudowudo/logic/parser/DateTimeParser.java
@@ -231,8 +231,9 @@ public class DateTimeParser {
      * @author darren
      */
     public static boolean isLastWeek(LocalDateTime ldt) {
-        LocalDateTime startOfCurrentWeek = LocalDateTime.now().with(DayOfWeek.MONDAY);
-        return ldt.isBefore(startOfCurrentWeek) && computeDaysTo(ldt) >= -7 && computeDaysTo(ldt) < 0;
+        LocalDate firstDayOfThisWeek = LocalDate.now().with(DayOfWeek.MONDAY);
+        LocalDate lastDayOfLastLastWeek = firstDayOfThisWeek.minusDays(8);
+        return ldt.toLocalDate().isBefore(firstDayOfThisWeek) && ldt.toLocalDate().isAfter(lastDayOfLastLastWeek);
     }
     
     /**
@@ -245,8 +246,9 @@ public class DateTimeParser {
      * @author darren
      */
     public static boolean isThisWeek(LocalDateTime ldt) {
-        LocalDateTime startOfCurrentWeek = LocalDateTime.now().with(DayOfWeek.MONDAY).minusDays(1);
-        return ldt.isAfter(startOfCurrentWeek) && computeDaysTo(ldt) >= 0 && computeDaysTo(ldt) < 7;
+        LocalDate lastDayOfLastWeek = LocalDate.now().with(DayOfWeek.MONDAY).minusDays(1);
+        LocalDate firstDayOfNextWeek = lastDayOfLastWeek.plusDays(8);
+        return ldt.toLocalDate().isAfter(lastDayOfLastWeek) && ldt.toLocalDate().isBefore(firstDayOfNextWeek);
     }
     
     /**
@@ -259,8 +261,9 @@ public class DateTimeParser {
      * @author darren
      */
     public static boolean isNextWeek(LocalDateTime ldt) {
-        LocalDateTime endOfCurrentWeek = LocalDateTime.now().with(DayOfWeek.SUNDAY);
-        return ldt.isAfter(endOfCurrentWeek) && computeDaysTo(ldt) >= 7 && computeDaysTo(ldt) < 14;
+        LocalDate endOfCurrentWeek = LocalDate.now().with(DayOfWeek.SUNDAY);
+        LocalDate firstDayOfNextNextWeek = endOfCurrentWeek.plusDays(8);
+        return ldt.toLocalDate().isAfter(endOfCurrentWeek) && ldt.toLocalDate().isBefore(firstDayOfNextNextWeek);
     }
     
     /**

--- a/src/main/java/seedu/sudowudo/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/sudowudo/logic/parser/DateTimeParser.java
@@ -209,6 +209,49 @@ public class DateTimeParser {
     }
 
     /**
+     * Check if the given java.time.LocalDateTime object is within the previous week
+     * from the local system time.
+     * 
+     * A week starts on Monday.
+     * 
+     * @param ldt
+     * @return true if the LocalDateTime is within the previous week from local system time.
+     * @author darren
+     */
+    public static boolean isLastWeek(LocalDateTime ldt) {
+        LocalDateTime startOfCurrentWeek = LocalDateTime.now().with(DayOfWeek.MONDAY);
+        return ldt.isBefore(startOfCurrentWeek) && computeDaysTo(ldt) >= -7 && computeDaysTo(ldt) < 0;
+    }
+    
+    /**
+     * Check if the given java.time.LocalDateTime object is within this week of the local system time.
+     * 
+     * A week starts on Monday.
+     * 
+     * @param ldt
+     * @return true if the LocalDateTime is within this week in local system time.
+     * @author darren
+     */
+    public static boolean isThisWeek(LocalDateTime ldt) {
+        LocalDateTime startOfCurrentWeek = LocalDateTime.now().with(DayOfWeek.MONDAY).minusDays(1);
+        return ldt.isAfter(startOfCurrentWeek) && computeDaysTo(ldt) >= 0 && computeDaysTo(ldt) < 7;
+    }
+    
+    /**
+     * Check if the given java.time.LocalDateTime object is within next week of the local system time.
+     * 
+     * A week starts on Monday.
+     * 
+     * @param ldt
+     * @return true if the LocalDateTime is within the next week from local system time.
+     * @author darren
+     */
+    public static boolean isNextWeek(LocalDateTime ldt) {
+        LocalDateTime endOfCurrentWeek = LocalDateTime.now().with(DayOfWeek.SUNDAY);
+        return ldt.isAfter(endOfCurrentWeek) && computeDaysTo(ldt) >= 7 && computeDaysTo(ldt) < 14;
+    }
+    
+    /**
      * Helper method for casting java.util.Date to java.time.LocalDateTime
      * 
      * @param date
@@ -313,27 +356,26 @@ public class DateTimeParser {
 
     /**
      * Extracts the day-of-week component of a java.time.LocalDateTime object
-     * and returns it in long or short format (Monday or Mon)
+     * and returns it in long format (e.g. Monday)
      * 
      * @param ldt
-     * @param isLongFormat
-     *            result is long format?
-     * @return day-of-week
+     * @return day-of-week in long format
      * @author darren
      */
-    private static String extractDayOfWeek(LocalDateTime ldt, boolean isLongFormat) {
-        if (isLongFormat) {
-            return ldt.toLocalDate().format(LONG_DAYOFWEEK);
-        }
-        return ldt.toLocalDate().format(SHORT_DAYOFWEEK);
-    }
-
     public static String extractLongDayOfWeek(LocalDateTime ldt) {
-        return extractDayOfWeek(ldt, true);
+        return ldt.toLocalDate().format(LONG_DAYOFWEEK);
     }
 
+    /**
+     * Extracts the day-of-week component of a java.time.LocalDateTime object
+     * and returns it in short format (e.g. Mon)
+     * 
+     * @param ldt
+     * @return day-of-week in short format
+     * @author darren
+     */
     public static String extractShortDayOfWeek(LocalDateTime ldt) {
-        return extractDayOfWeek(ldt, false);
+        return ldt.toLocalDate().format(SHORT_DAYOFWEEK);
     }
 
     /**
@@ -345,13 +387,11 @@ public class DateTimeParser {
      * @author darren
      */
     private static String makeRelativePrefix(LocalDateTime ldt) {
-        LocalDateTime startOfCurrentWeek = LocalDateTime.now().with(DayOfWeek.MONDAY);
-        LocalDateTime startOfNextWeek = startOfCurrentWeek.with(DayOfWeek.MONDAY);
-        if (computeDaysTo(ldt) > -14 && ldt.isBefore(startOfCurrentWeek)) {
+        if (isLastWeek(ldt)) {
             return LAST_WEEK_REF;
-        } else if (computeDaysTo(ldt) < 7 && ldt.isBefore(startOfNextWeek)) {
+        } else if (isThisWeek(ldt)) {
             return THIS_WEEK_REF;
-        } else if (computeDaysTo(ldt) < 14) {
+        } else if (isNextWeek(ldt)) {
             return NEXT_WEEK_REF;
         }
         return EMPTY_STRING;

--- a/src/main/java/seedu/sudowudo/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/sudowudo/logic/parser/DateTimeParser.java
@@ -25,6 +25,7 @@ public class DateTimeParser {
     // handy strings for making pretty dates
     public static final String EMPTY_STRING = "";
     public static final String SINGLE_WHITESPACE = " ";
+    public static final String YESTERDAY_DATE_REF = "Yesterday";
     public static final String TODAY_DATE_REF = "Today";
     public static final String TOMORROW_DATE_REF = "Tomorrow";
     public static final String LAST_WEEK_REF = "Last" + SINGLE_WHITESPACE;
@@ -154,7 +155,6 @@ public class DateTimeParser {
     public static boolean isSameDay(LocalDateTime ldt1, LocalDateTime ldt2) {
         return ldt1.toLocalDate().equals(ldt2.toLocalDate());
     }
-
     /**
      * Check if the given java.time.LocalDateTime object is the same date as the
      * current date on local system time
@@ -165,6 +165,18 @@ public class DateTimeParser {
      */
     public static boolean isToday(LocalDateTime ldt) {
         return isSameDay(ldt, LocalDateTime.now());
+    }
+
+    /**
+     * Check if the given java.time.LocalDateTime object is the same date as the
+     * yesterday relative to the local system time
+     * 
+     * @param ldt
+     * @return true if the LocalDateTime is for yesterday, false otherwise
+     * @author darren
+     */
+    public static boolean isYesterday(LocalDateTime ldt) {
+        return isSameDay(ldt, LocalDateTime.now().minusDays(1));
     }
 
     /**
@@ -313,7 +325,11 @@ public class DateTimeParser {
      * @return pretty date for this week
      */
     public static String extractPrettyDateTime(LocalDateTime ldt) {
-        // special case for today/tomorrow relative to local system time
+        // special case for yesterday/today/tomorrow relative to local system time
+        if (isYesterday(ldt)) {
+            return YESTERDAY_DATE_REF + PRETTY_COMMA_DELIMITER + extractTwelveHourTime(ldt);
+        }
+
         if (isToday(ldt)) {
             return TODAY_DATE_REF + PRETTY_COMMA_DELIMITER + extractTwelveHourTime(ldt);
         }

--- a/src/main/java/seedu/sudowudo/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/sudowudo/logic/parser/DateTimeParser.java
@@ -155,6 +155,7 @@ public class DateTimeParser {
     public static boolean isSameDay(LocalDateTime ldt1, LocalDateTime ldt2) {
         return ldt1.toLocalDate().equals(ldt2.toLocalDate());
     }
+
     /**
      * Check if the given java.time.LocalDateTime object is the same date as the
      * current date on local system time
@@ -221,28 +222,32 @@ public class DateTimeParser {
     }
 
     /**
-     * Check if the given java.time.LocalDateTime object is within the previous week
-     * from the local system time.
+     * Check if the given java.time.LocalDateTime object is within the previous
+     * week from the local system time.
      * 
      * A week starts on Monday.
      * 
      * @param ldt
-     * @return true if the LocalDateTime is within the previous week from local system time.
+     * @return true if the LocalDateTime is within the previous week from local
+     *         system time.
      * @author darren
      */
     public static boolean isLastWeek(LocalDateTime ldt) {
         LocalDate firstDayOfThisWeek = LocalDate.now().with(DayOfWeek.MONDAY);
         LocalDate lastDayOfLastLastWeek = firstDayOfThisWeek.minusDays(8);
-        return ldt.toLocalDate().isBefore(firstDayOfThisWeek) && ldt.toLocalDate().isAfter(lastDayOfLastLastWeek);
+        return ldt.toLocalDate().isBefore(firstDayOfThisWeek)
+                && ldt.toLocalDate().isAfter(lastDayOfLastLastWeek);
     }
-    
+
     /**
-     * Check if the given java.time.LocalDateTime object is within this week of the local system time.
+     * Check if the given java.time.LocalDateTime object is within this week of
+     * the local system time.
      * 
      * A week starts on Monday.
      * 
      * @param ldt
-     * @return true if the LocalDateTime is within this week in local system time.
+     * @return true if the LocalDateTime is within this week in local system
+     *         time.
      * @author darren
      */
     public static boolean isThisWeek(LocalDateTime ldt) {
@@ -250,22 +255,25 @@ public class DateTimeParser {
         LocalDate firstDayOfNextWeek = lastDayOfLastWeek.plusDays(8);
         return ldt.toLocalDate().isAfter(lastDayOfLastWeek) && ldt.toLocalDate().isBefore(firstDayOfNextWeek);
     }
-    
+
     /**
-     * Check if the given java.time.LocalDateTime object is within next week of the local system time.
+     * Check if the given java.time.LocalDateTime object is within next week of
+     * the local system time.
      * 
      * A week starts on Monday.
      * 
      * @param ldt
-     * @return true if the LocalDateTime is within the next week from local system time.
+     * @return true if the LocalDateTime is within the next week from local
+     *         system time.
      * @author darren
      */
     public static boolean isNextWeek(LocalDateTime ldt) {
         LocalDate endOfCurrentWeek = LocalDate.now().with(DayOfWeek.SUNDAY);
         LocalDate firstDayOfNextNextWeek = endOfCurrentWeek.plusDays(8);
-        return ldt.toLocalDate().isAfter(endOfCurrentWeek) && ldt.toLocalDate().isBefore(firstDayOfNextNextWeek);
+        return ldt.toLocalDate().isAfter(endOfCurrentWeek)
+                && ldt.toLocalDate().isBefore(firstDayOfNextNextWeek);
     }
-    
+
     /**
      * Helper method for casting java.util.Date to java.time.LocalDateTime
      * 
@@ -328,7 +336,8 @@ public class DateTimeParser {
      * @return pretty date for this week
      */
     public static String extractPrettyDateTime(LocalDateTime ldt) {
-        // special case for yesterday/today/tomorrow relative to local system time
+        // special case for yesterday/today/tomorrow relative to local system
+        // time
         if (isYesterday(ldt)) {
             return YESTERDAY_DATE_REF + PRETTY_COMMA_DELIMITER + extractTwelveHourTime(ldt);
         }
@@ -413,7 +422,7 @@ public class DateTimeParser {
         } else if (isNextWeek(ldt)) {
             return NEXT_WEEK_REF;
         }
-        
+
         // we should never reach this point
         return EMPTY_STRING;
     }

--- a/src/main/java/seedu/sudowudo/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/sudowudo/logic/parser/DateTimeParser.java
@@ -21,6 +21,9 @@ import org.ocpsoft.prettytime.nlp.parse.DateGroup;
  * @author darren
  */
 public class DateTimeParser {
+    private static final int FIRST_DATETIME_TOKEN = 0;
+    private static final int SECOND_DATETIME_TOKEN = 1;
+
     // the part of the command that contains the temporal part of the command
     private String datetime;
 
@@ -78,7 +81,7 @@ public class DateTimeParser {
             return null;
         }
 
-        return changeDateToLocalDateTime(this.dates.get(0));
+        return changeDateToLocalDateTime(this.dates.get(FIRST_DATETIME_TOKEN));
     }
 
     public LocalDateTime extractEndDate() {
@@ -88,16 +91,16 @@ public class DateTimeParser {
             return null;
         }
 
-        return changeDateToLocalDateTime(this.dates.get(1));
+        return changeDateToLocalDateTime(this.dates.get(SECOND_DATETIME_TOKEN));
     }
 
     public boolean isRecurring() {
-        return this.dategroups.get(0).isRecurring();
+        return this.dategroups.get(FIRST_DATETIME_TOKEN).isRecurring();
     }
 
     public LocalDateTime getRecurEnd() {
         return changeDateToLocalDateTime(
-                this.dategroups.get(0).getRecursUntil());
+                this.dategroups.get(FIRST_DATETIME_TOKEN).getRecursUntil());
     }
 
     /**

--- a/src/main/java/seedu/sudowudo/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/sudowudo/logic/parser/DateTimeParser.java
@@ -22,27 +22,9 @@ import org.ocpsoft.prettytime.nlp.parse.DateGroup;
  * @author darren
  */
 public class DateTimeParser {
-    private static final int FIRST_DATETIME_TOKEN = 0;
-    private static final int SECOND_DATETIME_TOKEN = 1;
-
-    // the part of the command that contains the temporal part of the command
-    private String datetime;
-
-    // PrettyTimeParser object
-    // careful of name collision with our own Parser object
-    private static PrettyTimeParser parser = new PrettyTimeParser();
-
-    // PrettyTime formatter
-    private static PrettyTime prettytime = new PrettyTime();
-
-    // result from parser
-    private List<DateGroup> dategroups;
-    private List<Date> dates;
-
+    // handy strings for making pretty dates
     public static final String EMPTY_STRING = "";
     public static final String SINGLE_WHITESPACE = " ";
-
-    // handy strings for making pretty dates
     public static final String TODAY_DATE_REF = "Today";
     public static final String TOMORROW_DATE_REF = "Tomorrow";
     public static final String LAST_WEEK_REF = "Last" + SINGLE_WHITESPACE;
@@ -64,13 +46,31 @@ public class DateTimeParser {
     public static final DateTimeFormatter SHORT_DAYOFWEEK = DateTimeFormatter
             .ofPattern("EEE");
 
-    public static DateTimeParser INSTANCE = new DateTimeParser();
+    public static DateTimeParser instance = new DateTimeParser();
+
+    private static final int FIRST_DATETIME_TOKEN = 0;
+    private static final int SECOND_DATETIME_TOKEN = 1;
+
+    // PrettyTimeParser object
+    // careful of name collision with our own Parser object
+    private static PrettyTimeParser parser = new PrettyTimeParser();
+
+    // PrettyTime formatter
+    private static PrettyTime prettytime = new PrettyTime();
+
+    // the part of the command that contains the temporal part of the command
+    private String datetime;
+
+    // result from parser
+    private List<DateGroup> dategroups;
+    private List<Date> dates;
+
+    private DateTimeParser() {}
     
     public static DateTimeParser getInstance() {
-        return INSTANCE;
+        return instance;
     }
     
-    private DateTimeParser() {}
     
     /**
      * Uses the DateTimeParser service to parse a string containing possible

--- a/src/main/java/seedu/sudowudo/logic/parser/DateTimeParser.java
+++ b/src/main/java/seedu/sudowudo/logic/parser/DateTimeParser.java
@@ -413,6 +413,8 @@ public class DateTimeParser {
         } else if (isNextWeek(ldt)) {
             return NEXT_WEEK_REF;
         }
+        
+        // we should never reach this point
         return EMPTY_STRING;
     }
 

--- a/src/main/java/seedu/sudowudo/logic/parser/Parser.java
+++ b/src/main/java/seedu/sudowudo/logic/parser/Parser.java
@@ -47,17 +47,19 @@ public class Parser {
     /**
      * Used for initial separation of command word and args.
      */
-    private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<commandWord>\\S+)(?<arguments>.*)");
+    private static final Pattern BASIC_COMMAND_FORMAT = Pattern
+            .compile("(?<commandWord>\\S+)(?<arguments>.*)");
 
     // one or more keywords separated by whitespace
     private static final Pattern KEYWORDS_ARGS_FORMAT = Pattern.compile("(?<keywords>\\S+(?:\\s+\\S+)*)");
 
     // item has description and a string representing time to be processed
     private static final Pattern ITEM_DATA_ARGS_FORMAT = Pattern.compile("(.*)\\\"(.*)\\\"(.*)");
-    
+
     private static final Pattern TASK_DATA_ARGS_FORMAT = Pattern.compile("(.*)\\\"(.*)\\\"");
 
-    private static final Pattern ITEM_EDIT_ARGS_FORMAT = Pattern.compile("(?<targetIndex>\\d+)\\s+(?<arguments>.*)");
+    private static final Pattern ITEM_EDIT_ARGS_FORMAT = Pattern
+            .compile("(?<targetIndex>\\d+)\\s+(?<arguments>.*)");
 
     private static final String TASK_NO_DATE_DATA = "nothing";
     private static final Pattern ITEM_INDEX_ARGS_FORMAT = Pattern.compile("(?<targetIndex>.+)");
@@ -69,7 +71,10 @@ public class Parser {
     private static final Pattern COMMAND_DESCRIPTION_SEARCH_FORMAT = Pattern.compile("\"([^\"]*)\"");
     private static final Pattern COMMAND_TAG_SEARCH_FORMAT = Pattern.compile("#([^ ]+)");
 
-    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+    private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter
+            .ofPattern("yyyy-MM-dd HH:mm");
+
+    private final DateTimeParser dtparser = DateTimeParser.getInstance();
 
     public enum Field {
         NAME("name"), START_DATE("start_date"), END_DATE("end_date"), START_TIME("start_time"), END_TIME(
@@ -87,14 +92,14 @@ public class Parser {
     }
 
     private static Parser instance = new Parser();
+
     private Parser() {
     }
-    
-    public static Parser getInstance(){
+
+    public static Parser getInstance() {
         return instance;
     }
 
-    
     /**
      * Parses user input into command for execution.
      *
@@ -105,63 +110,56 @@ public class Parser {
     public Command parseCommand(String userInput) {
         final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
         if (!matcher.matches()) {
-            return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
+            return new IncorrectCommand(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
         }
 
         final String commandWord = matcher.group("commandWord");
         final String arguments = matcher.group("arguments");
         Command toReturn;
+        
         switch (commandWord) {
-
         case AddCommand.COMMAND_WORD:
             toReturn = prepareAdd(arguments);
             break;
-
         case SelectCommand.COMMAND_WORD:
             toReturn = prepareSelect(arguments);
             break;
-
         case DeleteCommand.COMMAND_WORD:
             toReturn = prepareDelete(arguments);
             break;
-
         case ClearCommand.COMMAND_WORD:
             toReturn = new ClearCommand();
             break;
-		case FindCommand.COMMAND_WORD:
-			toReturn = prepareFind(arguments);
-			break;
-
+        case FindCommand.COMMAND_WORD:
+            toReturn = prepareFind(arguments);
+            break;
         case EditCommand.COMMAND_WORD:
             toReturn = prepareEdit(arguments);
             break;
-
         case ListCommand.COMMAND_WORD:
             toReturn = prepareList(arguments);
             break;
-
         case ExitCommand.COMMAND_WORD:
             toReturn = new ExitCommand();
             break;
-
         case HelpCommand.COMMAND_WORD:
             toReturn = new HelpCommand();
             break;
-
         case DoneCommand.COMMAND_WORD:
             toReturn = prepareDone(arguments);
             break;
-            
         case UndoCommand.COMMAND_WORD:
             toReturn = new UndoCommand();
             break;
-
         default:
             toReturn = new IncorrectCommand(MESSAGE_UNKNOWN_COMMAND);
+            break;
         }
+
         toReturn.setRawCommand(userInput);
         return toReturn;
-	};
+    };
 
     /**
      * Parses arguments in the context of the list item command.
@@ -177,7 +175,8 @@ public class Parser {
         } else if (isValidType(argument)) {
             return new ListCommand(argument.trim().toLowerCase());
         } else {
-            return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE));
+            return new IncorrectCommand(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ListCommand.MESSAGE_USAGE));
         }
     }
 
@@ -190,7 +189,7 @@ public class Parser {
      */
     public static boolean isValidType(String argument) {
         assert argument != null;
-        try{
+        try {
             Item.Type.valueOf(argument.trim().toUpperCase());
         } catch (IllegalArgumentException iae) {
             return false;
@@ -214,7 +213,8 @@ public class Parser {
                                                                               // string
                                                                               // format
         if (!itemMatch.matches() && !taskMatch.matches()) {
-            return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
+            return new IncorrectCommand(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
         try {
             if (taskMatch.matches()) {
@@ -243,7 +243,8 @@ public class Parser {
         // found
         String postFix = itemMatch.group(COMMAND_TYPE_FIELD_NUMBER).trim();
         if (!postFix.equals(EMPTY_STRING)) {
-            return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
+            return new IncorrectCommand(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
         String description = itemMatch.group(COMMAND_DESCRIPTION_FIELD_NUMBER).trim();
         String timeStr = itemMatch.group(COMMAND_TIME_FIELD_NUMBER).trim();
@@ -263,7 +264,8 @@ public class Parser {
     private Command parseNewTask(final Matcher itemMatch, String args) throws IllegalValueException {
         String postFix = itemMatch.group(COMMAND_TYPE_FIELD_NUMBER).trim();
         if (!postFix.equals(EMPTY_STRING)) {
-            return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
+            return new IncorrectCommand(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
         String description = itemMatch.group(COMMAND_DESCRIPTION_FIELD_NUMBER).trim();
         String argsWithoutDescription = args.replace(description, "");
@@ -271,8 +273,8 @@ public class Parser {
     }
 
     /**
-     * Extracts the new item's tags from the add command's tag arguments
-     * string. Merges duplicate tag strings.
+     * Extracts the new item's tags from the add command's tag arguments string.
+     * Merges duplicate tag strings.
      * 
      * @@author A0131560U
      */
@@ -312,7 +314,8 @@ public class Parser {
             final Set<String> keywordSet = extractKeywords(args);
             return new DeleteCommand(keywordSet);
         } catch (IllegalValueException e) {
-            return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+            return new IncorrectCommand(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
         }
     }
 
@@ -328,7 +331,8 @@ public class Parser {
     private Command prepareDone(String args) {
         Optional<Integer> index = parseIndex(args);
         if (!index.isPresent()) {
-            return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DoneCommand.MESSAGE_USAGE));
+            return new IncorrectCommand(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DoneCommand.MESSAGE_USAGE));
         }
 
         return new DoneCommand(index.get());
@@ -345,7 +349,8 @@ public class Parser {
     private Command prepareSelect(String args) {
         Optional<Integer> index = parseIndex(args);
         if (!index.isPresent()) {
-            return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, SelectCommand.MESSAGE_USAGE));
+            return new IncorrectCommand(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, SelectCommand.MESSAGE_USAGE));
         }
 
         return new SelectCommand(index.get());
@@ -370,7 +375,7 @@ public class Parser {
 
     }
 
-    //@@author A0131560U
+    // @@author A0131560U
     /**
      * Parses arguments in the context of the find item command.
      *
@@ -380,20 +385,24 @@ public class Parser {
      * @@author A0131560U
      */
     private Command prepareFind(String args) {
-        try{
+        try {
             final Set<String> keywordSet = extractKeywords(args);
             return new FindCommand(keywordSet);
-        } catch (IllegalValueException ive){
-            return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        } catch (IllegalValueException ive) {
+            return new IncorrectCommand(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
     }
 
-    //@@author A0131560U
+    // @@author A0131560U
     /**
-     * Extracts description, tag and DateTime keywords from args and returns them as a set.
+     * Extracts description, tag and DateTime keywords from args and returns
+     * them as a set.
+     * 
      * @param unfiltered
      * @return
-     * @throws IllegalValueException if arguments are not in the correct format
+     * @throws IllegalValueException
+     *             if arguments are not in the correct format
      */
     private Set<String> extractKeywords(String unfiltered) throws IllegalValueException {
         final Matcher matcher = KEYWORDS_ARGS_FORMAT.matcher(unfiltered.trim());
@@ -410,18 +419,18 @@ public class Parser {
 
         if (!unfiltered.isEmpty()) {
             boolean isDateTimeValid = extractDateTimeFromKeywords(unfiltered, keywordSet);
-            if (!isDateTimeValid){
+            if (!isDateTimeValid) {
                 throw new IllegalValueException("Input does not match expected format for DateTime");
             }
         }
-        
-        if (keywordSet.isEmpty()){
+
+        if (keywordSet.isEmpty()) {
             throw new IllegalValueException("No keywords found");
         }
         return keywordSet;
     }
-    
-    //@@A0092390E
+
+    // @@A0092390E
     /**
      * Parses arguments in the context of the Edit item command
      * 
@@ -432,7 +441,8 @@ public class Parser {
     private Command prepareEdit(String args) {
         final Matcher matcher = ITEM_EDIT_ARGS_FORMAT.matcher(args.trim());
         if (!matcher.matches()) {
-            return new IncorrectCommand(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
+            return new IncorrectCommand(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
         }
         int index = Integer.parseInt(matcher.group("targetIndex"));
         ArrayList<String> arguments = parseMultipleParameters(matcher.group("arguments"), ',');
@@ -443,7 +453,7 @@ public class Parser {
         }
     }
 
-    //@@author A0131560U
+    // @@author A0131560U
     /**
      * Extracts a valid DateTime from the provided arguments and adds them to
      * the keywordSet, then returns true. If the arguments do not form a valid
@@ -459,12 +469,13 @@ public class Parser {
         assert args != null;
         assert !args.isEmpty();
         assert keywordSet != null;
-        DateTimeParser dateArgs = new DateTimeParser(args);
 
-        if (dateArgs.extractStartDate() != null) {
-            keywordSet.add(dateArgs.extractStartDate().format(DATE_TIME_FORMATTER));
-            if (dateArgs.extractEndDate() != null) {
-                keywordSet.add(dateArgs.extractEndDate().format(DATE_TIME_FORMATTER));
+        this.dtparser.parse(args);
+
+        if (dtparser.extractStartDate() != null) {
+            keywordSet.add(dtparser.extractStartDate().format(DATE_TIME_FORMATTER));
+            if (dtparser.extractEndDate() != null) {
+                keywordSet.add(dtparser.extractEndDate().format(DATE_TIME_FORMATTER));
             }
             return true;
         } else {
@@ -472,7 +483,7 @@ public class Parser {
         }
     }
 
-    //@@author A0131560U
+    // @@author A0131560U
     /**
      * Given a specific pattern, extracts all phrases that match the pattern and
      * adds them to keywordSet. Returns args string without the keywords that
@@ -504,55 +515,55 @@ public class Parser {
      * @author darren
      */
 
-	 //@@author A0147609X
-	/**
-	 * splits multi-arguments into a nice ArrayList of strings
-	 * 
-	 * @param params
-	 *            comma-separated parameters
-	 * @param delimiter
-	 *            delimiting character
-	 * @return ArrayList<String> of parameters
-	 * @author darren
-	 */
-	public static ArrayList<String> parseMultipleParameters(String params, char delimiter) {
-		CSVParser parser = new CSVParser(delimiter);
+    // @@author A0147609X
+    /**
+     * splits multi-arguments into a nice ArrayList of strings
+     * 
+     * @param params
+     *            comma-separated parameters
+     * @param delimiter
+     *            delimiting character
+     * @return ArrayList<String> of parameters
+     * @author darren
+     */
+    public static ArrayList<String> parseMultipleParameters(String params, char delimiter) {
+        CSVParser parser = new CSVParser(delimiter);
 
-		try {
-			String[] tokens = parser.parseLine(params);
+        try {
+            String[] tokens = parser.parseLine(params);
 
-			// strip leading and trailing whitespaces
-			for (int i = 0; i < tokens.length; i++) {
-				tokens[i] = tokens[i].trim();
-			}
+            // strip leading and trailing whitespaces
+            for (int i = 0; i < tokens.length; i++) {
+                tokens[i] = tokens[i].trim();
+            }
 
-			return new ArrayList<>(Arrays.asList(tokens));
-		} catch (IOException ioe) {
-			System.out.println(ioe.getMessage());
-		}
+            return new ArrayList<>(Arrays.asList(tokens));
+        } catch (IOException ioe) {
+            System.out.println(ioe.getMessage());
+        }
 
-		return null;
-	}
-	//@@author 
+        return null;
+    }
+    // @@author
 
-	 //@@author A0147609X-unused
-	/**
-	 * checks field names are valid
-	 * 
-	 * @param fieldNames
-	 *            an ArrayList<String> of field names
-	 * @return true if all fields are valid, false otherwise
-	 * @author darren
-	 */
-	private static boolean fieldsAreValid(ArrayList<String> fieldNames) {
-		assert fieldNames != null;
-		for (String fieldName : fieldNames) {
-			try {
-				Field ret = Field.valueOf(fieldName.toUpperCase());
-			} catch (IllegalArgumentException iae) {
-				return false;
-			}
-		}
-		return true;
-	}
+    // @@author A0147609X-unused
+    /**
+     * checks field names are valid
+     * 
+     * @param fieldNames
+     *            an ArrayList<String> of field names
+     * @return true if all fields are valid, false otherwise
+     * @author darren
+     */
+    private static boolean fieldsAreValid(ArrayList<String> fieldNames) {
+        assert fieldNames != null;
+        for (String fieldName : fieldNames) {
+            try {
+                Field ret = Field.valueOf(fieldName.toUpperCase());
+            } catch (IllegalArgumentException iae) {
+                return false;
+            }
+        }
+        return true;
+    }
 }

--- a/src/main/java/seedu/sudowudo/logic/parser/Parser.java
+++ b/src/main/java/seedu/sudowudo/logic/parser/Parser.java
@@ -67,7 +67,7 @@ public class Parser {
     private static final Pattern COMMAND_TAG_SEARCH_FORMAT = Pattern.compile("#([^ ]+)");
     private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter
             .ofPattern("yyyy-MM-dd HH:mm");
-    private static final DateTimeParser dtParser = DateTimeParser.getInstance();
+    private DateTimeParser dtParser = DateTimeParser.getInstance();
     private static Parser instance = new Parser();
 
     private Parser() {
@@ -447,7 +447,7 @@ public class Parser {
         assert !args.isEmpty();
         assert keywordSet != null;
 
-        this.dtParser.parse(args);
+        dtParser.parse(args);
 
         if (dtParser.extractStartDate() != null) {
             keywordSet.add(dtParser.extractStartDate().format(DATE_TIME_FORMATTER));

--- a/src/main/java/seedu/sudowudo/logic/parser/Parser.java
+++ b/src/main/java/seedu/sudowudo/logic/parser/Parser.java
@@ -38,12 +38,12 @@ import seedu.sudowudo.model.item.Item;
  */
 public class Parser {
 
-    private static final String EMPTY_STRING = "";
     public static final String COMMAND_TAG_REGEX = "#(.*)";
     public static final String COMMAND_DESCRIPTION_REGEX = "\"(.*)\"";
     public static final String COMMAND_TAG_PREFIX = "#";
     public static final String COMMAND_DESCRIPTION_PREFIX = "\"";
 
+    private static final String EMPTY_STRING = "";
     /**
      * Used for initial separation of command word and args.
      */
@@ -55,42 +55,19 @@ public class Parser {
 
     // item has description and a string representing time to be processed
     private static final Pattern ITEM_DATA_ARGS_FORMAT = Pattern.compile("(.*)\\\"(.*)\\\"(.*)");
-
     private static final Pattern TASK_DATA_ARGS_FORMAT = Pattern.compile("(.*)\\\"(.*)\\\"");
-
     private static final Pattern ITEM_EDIT_ARGS_FORMAT = Pattern
             .compile("(?<targetIndex>\\d+)\\s+(?<arguments>.*)");
-
     private static final String TASK_NO_DATE_DATA = "nothing";
     private static final Pattern ITEM_INDEX_ARGS_FORMAT = Pattern.compile("(?<targetIndex>.+)");
-
     private static final int COMMAND_DESCRIPTION_FIELD_NUMBER = 2;
     private static final int COMMAND_TYPE_FIELD_NUMBER = 1;
     private static final int COMMAND_TIME_FIELD_NUMBER = 3;
-
     private static final Pattern COMMAND_DESCRIPTION_SEARCH_FORMAT = Pattern.compile("\"([^\"]*)\"");
     private static final Pattern COMMAND_TAG_SEARCH_FORMAT = Pattern.compile("#([^ ]+)");
-
     private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter
             .ofPattern("yyyy-MM-dd HH:mm");
-
-    private final DateTimeParser dtparser = DateTimeParser.getInstance();
-
-    public enum Field {
-        NAME("name"), START_DATE("start_date"), END_DATE("end_date"), START_TIME("start_time"), END_TIME(
-                "end_time"), DATE("date"), TIME("time");
-
-        private String field_name;
-
-        Field(String name) {
-            this.field_name = name;
-        }
-
-        public String getFieldName() {
-            return this.field_name;
-        }
-    }
-
+    private static final DateTimeParser dtParser = DateTimeParser.getInstance();
     private static Parser instance = new Parser();
 
     private Parser() {
@@ -470,12 +447,12 @@ public class Parser {
         assert !args.isEmpty();
         assert keywordSet != null;
 
-        this.dtparser.parse(args);
+        this.dtParser.parse(args);
 
-        if (dtparser.extractStartDate() != null) {
-            keywordSet.add(dtparser.extractStartDate().format(DATE_TIME_FORMATTER));
-            if (dtparser.extractEndDate() != null) {
-                keywordSet.add(dtparser.extractEndDate().format(DATE_TIME_FORMATTER));
+        if (dtParser.extractStartDate() != null) {
+            keywordSet.add(dtParser.extractStartDate().format(DATE_TIME_FORMATTER));
+            if (dtParser.extractEndDate() != null) {
+                keywordSet.add(dtParser.extractEndDate().format(DATE_TIME_FORMATTER));
             }
             return true;
         } else {
@@ -546,24 +523,4 @@ public class Parser {
     }
     // @@author
 
-    // @@author A0147609X-unused
-    /**
-     * checks field names are valid
-     * 
-     * @param fieldNames
-     *            an ArrayList<String> of field names
-     * @return true if all fields are valid, false otherwise
-     * @author darren
-     */
-    private static boolean fieldsAreValid(ArrayList<String> fieldNames) {
-        assert fieldNames != null;
-        for (String fieldName : fieldNames) {
-            try {
-                Field ret = Field.valueOf(fieldName.toUpperCase());
-            } catch (IllegalArgumentException iae) {
-                return false;
-            }
-        }
-        return true;
-    }
 }

--- a/src/test/java/seedu/sudowudo/logic/parser/DateTimeParserTest.java
+++ b/src/test/java/seedu/sudowudo/logic/parser/DateTimeParserTest.java
@@ -13,6 +13,8 @@ import java.util.Calendar;
 import java.util.Date;
 
 import org.junit.Test;
+import org.ocpsoft.prettytime.nlp.PrettyTimeParser;
+import org.ocpsoft.prettytime.nlp.parse.DateGroup;
 
 //@@author A0147609X
 /**
@@ -39,13 +41,6 @@ public class DateTimeParserTest {
         String input = "16 september 2016 5pm to 17 september 2016 6pm";
         parser.parse(input);
         assertEquals(input, parser.getDateTime());
-    }
-    
-    @Test
-    public void getDateGroup_validIndex_dateGroupReturned() {
-        String input = "16 september 2016 5pm to 17 september 2016 6pm";
-        parser.parse(input);
-        
     }
     
     @Test

--- a/src/test/java/seedu/sudowudo/logic/parser/DateTimeParserTest.java
+++ b/src/test/java/seedu/sudowudo/logic/parser/DateTimeParserTest.java
@@ -136,6 +136,12 @@ public class DateTimeParserTest {
     }
 
     @Test
+    public void extractPrettyDateTime_lastWeek_lastWeekReference() {
+        String expected = DateTimeParser.LAST_WEEK_REF + LDT_TODAY_LAST_WEEK.format(DateTimeParser.LONG_DAYOFWEEK) + DateTimeParser.PRETTY_COMMA_DELIMITER + LDT_TODAY_LAST_WEEK.format(DateTimeParser.TWELVE_HOUR_TIME);
+        assertEquals(expected, DateTimeParser.extractPrettyDateTime(LDT_TODAY_LAST_WEEK));
+    }
+    
+    @Test
     public void extractPrettyDateTime_oneYearFromNow_explicitDateFormat() {
         LocalDateTime oneYearFromNow = LDT_TODAY.plusYears(1);
         DateTimeFormatter explicitFormat = DateTimeFormatter.ofPattern("EEE d MMM yyyy, hh:mma");

--- a/src/test/java/seedu/sudowudo/logic/parser/DateTimeParserTest.java
+++ b/src/test/java/seedu/sudowudo/logic/parser/DateTimeParserTest.java
@@ -115,10 +115,35 @@ public class DateTimeParserTest {
     /*
      * Tests for datetime prettifier methods
      */
+
     @Test
     public void extractPrettyDateTime_today_todayReference() {
-        String expected = "Today, 12:00PM";
+        String expected = DateTimeParser.TODAY_DATE_REF + DateTimeParser.PRETTY_COMMA_DELIMITER + "12:00PM";
         assertEquals(expected, DateTimeParser.extractPrettyDateTime(LDT_TODAY));
+    }
+
+    @Test
+    public void extractPrettyDateTime_tomorrow_tomorrowReference() {
+        String expected = DateTimeParser.TOMORROW_DATE_REF + DateTimeParser.PRETTY_COMMA_DELIMITER + "12:00PM";
+        assertEquals(expected, DateTimeParser.extractPrettyDateTime(LDT_TOMORROW));
+    }
+
+    @Test
+    public void extractPrettyDateTime_yesterday_yesterdayReference() {
+        String expected = DateTimeParser.YESTERDAY_DATE_REF + DateTimeParser.PRETTY_COMMA_DELIMITER + "12:00PM";
+        assertEquals(expected, DateTimeParser.extractPrettyDateTime(LDT_YESTERDAY));
+    }
+
+    //@Test
+    public void extractPrettyDateTime_nextWeek_nextDayOfWeekReference() {
+        String expected = DateTimeParser.NEXT_WEEK_REF + "Monday" + DateTimeParser.PRETTY_COMMA_DELIMITER + "12:00PM";
+        assertEquals(expected, DateTimeParser.extractPrettyDateTime(LDT_NEXT_MONDAY));
+    }
+
+    //@Test
+    public void extractPrettyDateTime_lastWeek_lastDayOfWeekReference() {
+        String expected = DateTimeParser.LAST_WEEK_REF + "Sunday" + DateTimeParser.PRETTY_COMMA_DELIMITER + "12:00PM";
+        assertEquals(expected, DateTimeParser.extractPrettyDateTime(LDT_LAST_SUNDAY));
     }
     
     private static Date makeDate(int year, int month, int day, int hour, int minute) {

--- a/src/test/java/seedu/sudowudo/logic/parser/DateTimeParserTest.java
+++ b/src/test/java/seedu/sudowudo/logic/parser/DateTimeParserTest.java
@@ -7,6 +7,7 @@ import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
 import java.time.temporal.TemporalAdjusters;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -134,16 +135,33 @@ public class DateTimeParserTest {
         assertEquals(expected, DateTimeParser.extractPrettyDateTime(LDT_YESTERDAY));
     }
 
-    //@Test
-    public void extractPrettyDateTime_nextWeek_nextDayOfWeekReference() {
-        String expected = DateTimeParser.NEXT_WEEK_REF + "Monday" + DateTimeParser.PRETTY_COMMA_DELIMITER + "12:00PM";
-        assertEquals(expected, DateTimeParser.extractPrettyDateTime(LDT_NEXT_MONDAY));
+    @Test
+    public void extractPrettyDateTime_oneYearFromNow_explicitDateFormat() {
+        LocalDateTime oneYearFromNow = LDT_TODAY.plusYears(1);
+        DateTimeFormatter explicitFormat = DateTimeFormatter.ofPattern("EEE d MMM yyyy, hh:mma");
+        String expected = oneYearFromNow.format(explicitFormat);
+        assertEquals(expected, DateTimeParser.extractPrettyDateTime(oneYearFromNow));
+    }
+    
+    @Test
+    public void extractPrettyItemCardDateTime_nullStart_prettyEndDateTimeOnly() {
+        String expected = DateTimeParser.extractPrettyDateTime(LDT_TODAY);
+        assertEquals(expected, DateTimeParser.extractPrettyItemCardDateTime(null, LDT_TODAY));
     }
 
-    //@Test
-    public void extractPrettyDateTime_lastWeek_lastDayOfWeekReference() {
-        String expected = DateTimeParser.LAST_WEEK_REF + "Sunday" + DateTimeParser.PRETTY_COMMA_DELIMITER + "12:00PM";
-        assertEquals(expected, DateTimeParser.extractPrettyDateTime(LDT_LAST_SUNDAY));
+    @Test
+    public void extractPrettyItemCardDateTime_nullEnd_prettyStartDateTimeOnly() {
+        String expected = DateTimeParser.extractPrettyDateTime(LDT_TODAY);
+        assertEquals(expected, DateTimeParser.extractPrettyItemCardDateTime(LDT_TODAY, null));
+    }
+    
+    @Test
+    public void extractPrettyItemCardDateTime_sameDayStartEnd_sameDayPeriod() {
+        LocalDateTime start = LDT_TODAY;
+        LocalDateTime end = LDT_TODAY.plusMinutes(60);
+        assert start.isBefore(end);
+        String expected = DateTimeParser.extractPrettyDateTime(start) + DateTimeParser.PRETTY_TO_DELIMITER + DateTimeParser.extractTwelveHourTime(end);
+        assertEquals(expected, DateTimeParser.extractPrettyItemCardDateTime(start, end));
     }
     
     private static Date makeDate(int year, int month, int day, int hour, int minute) {

--- a/src/test/java/seedu/sudowudo/logic/parser/DateTimeParserTest.java
+++ b/src/test/java/seedu/sudowudo/logic/parser/DateTimeParserTest.java
@@ -3,9 +3,11 @@ package seedu.sudowudo.logic.parser;
 import static org.junit.Assert.*;
 import static org.junit.Assert.assertEquals;
 
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.temporal.TemporalAdjusters;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
@@ -20,8 +22,32 @@ import org.junit.Test;
  */
 public class DateTimeParserTest {
 
-    private DateTimeParser parser = DateTimeParser.getInstance();
+    // commonly used temporal markers
+    private static final LocalDateTime LDT_TODAY = LocalDateTime.now();
+    private static final LocalDateTime LDT_TOMORROW = LDT_TODAY.plusDays(1);
+    private static final LocalDateTime LDT_THIS_MONDAY = LDT_TODAY.with(DayOfWeek.MONDAY);
+    private static final LocalDateTime LDT_THIS_SUNDAY = LDT_TODAY.with(DayOfWeek.SUNDAY);
+    private static final LocalDateTime LDT_LAST_SUNDAY = LDT_TODAY.with(TemporalAdjusters.previous(DayOfWeek.SUNDAY));
+    private static final LocalDateTime LDT_TODAY_LAST_WEEK = LDT_TODAY.minusDays(7);
+    private static final LocalDateTime LDT_TODAY_NEXT_WEEK = LDT_TODAY.plusDays(7);
+    
 
+    private DateTimeParser parser = DateTimeParser.getInstance();
+    
+    @Test
+    public void getDateTime_validString_stringReturned() {
+        String input = "16 september 2016 5pm to 17 september 2016 6pm";
+        parser.parse(input);
+        assertEquals(input, parser.getDateTime());
+    }
+    
+    @Test
+    public void getDateGroup_validIndex_dateGroupReturned() {
+        String input = "16 september 2016 5pm to 17 september 2016 6pm";
+        parser.parse(input);
+        
+    }
+    
     @Test
     public void extractStartDate_explicitDate_correctStartDate() {
         String input = "16 september 2016 5pm to 17 september 2016 6pm";
@@ -199,44 +225,41 @@ public class DateTimeParserTest {
 
     @Test
     public void isSameDay_differentDay_false() {
-        LocalDateTime ldt1 = LocalDateTime.of(2016, 11, 11, 11, 11);
-        LocalDateTime ldt2 = LocalDateTime.of(2016, 11, 15, 19, 46);
-        assertEquals(false, DateTimeParser.isSameDay(ldt1, ldt2));
+        assertEquals(false, DateTimeParser.isSameDay(LDT_TODAY, LDT_TOMORROW));
     }
     
     @Test
     public void isToday_todaysDate_true() {
-        assertEquals(true, DateTimeParser.isToday(LocalDateTime.now()));
+        assertEquals(true, DateTimeParser.isToday(LDT_TODAY));
     }
 
     @Test
     public void isToday_tomorrowsDate_false() {
-        assertEquals(false, DateTimeParser.isToday(LocalDateTime.now().plusDays(1)));
+        assertEquals(false, DateTimeParser.isToday(LDT_TOMORROW));
     }
     
     @Test
     public void isTomorrow_tomorrowsDate_true() {
-        assertEquals(true, DateTimeParser.isTomorrow(LocalDateTime.now().plusDays(1)));
+        assertEquals(true, DateTimeParser.isTomorrow(LDT_TOMORROW));
     }
 
     @Test
     public void isTomorrow_todaysDate_false() {
-        assertEquals(false, DateTimeParser.isTomorrow(LocalDateTime.now()));
+        assertEquals(false, DateTimeParser.isTomorrow(LDT_TODAY));
     }
     
     @Test
     public void isWithinTwoWeeks_withinTwoWeeks_true() {
-        LocalDateTime ldt = LocalDateTime.now();
         for(int i = 0; i < 14; i++) {
-            assertEquals(true, DateTimeParser.isWithinTwoWeeks(ldt.plusDays(i)));
-            assertEquals(true, DateTimeParser.isWithinTwoWeeks(ldt.minusDays(i)));
+            assertEquals(true, DateTimeParser.isWithinTwoWeeks(LDT_TODAY.plusDays(i)));
+            assertEquals(true, DateTimeParser.isWithinTwoWeeks(LDT_TODAY.minusDays(i)));
         }
     }
     
     @Test
     public void isWithinTwoWeeks_outsideTwoWeeks_false() {
-        LocalDateTime ldtPlus = LocalDateTime.now().plusDays(14);
-        LocalDateTime ldtMinus = LocalDateTime.now().minusDays(14);
+        LocalDateTime ldtPlus = LDT_TODAY.plusDays(14);
+        LocalDateTime ldtMinus = LDT_TODAY.minusDays(14);
         for(int i = 0; i < 14; i++) {
             assertEquals(false, DateTimeParser.isWithinTwoWeeks(ldtPlus.plusDays(i)));
             assertEquals(false, DateTimeParser.isWithinTwoWeeks(ldtMinus.minusDays(i)));
@@ -245,13 +268,75 @@ public class DateTimeParserTest {
     
     @Test
     public void isWithinThisYear_withinYear_true() {
-        LocalDateTime ldt = LocalDateTime.now();
-        assertEquals(true, DateTimeParser.isWithinThisYear(ldt));
+        assertEquals(true, DateTimeParser.isWithinThisYear(LDT_TODAY));
     }
 
     @Test
     public void isWithinThisYear_outsideYear_false() {
-        LocalDateTime ldt = LocalDateTime.now().plusYears(1);
-        assertEquals(false, DateTimeParser.isWithinThisYear(ldt));
+        assertEquals(false, DateTimeParser.isWithinThisYear(LDT_TODAY.plusYears(1)));
+    }
+    
+    @Test
+    public void isLastWeek_insideLastWeek_true() {
+        // 7 days ago is obviously inside last week
+        assertEquals(true, DateTimeParser.isLastWeek(LDT_TODAY_LAST_WEEK));
+    }
+
+    @Test
+    public void isLastWeek_lastSunday_true() {
+        // final day of last week
+        assertEquals(true, DateTimeParser.isLastWeek(LDT_LAST_SUNDAY));
+    }
+
+    @Test
+    public void isLastWeek_outsideLastWeek_false() {
+        // today is obviously not last week
+        assertEquals(false, DateTimeParser.isLastWeek(LDT_TODAY));
+    }
+
+    @Test
+    public void isLastWeek_thisMonday_false() {
+        // first day of this week
+        assertEquals(false, DateTimeParser.isLastWeek(LDT_THIS_MONDAY));
+    }
+    
+    @Test
+    public void isThisWeek_today_true() {
+        assertEquals(true, DateTimeParser.isThisWeek(LDT_TODAY));
+    }
+
+    @Test
+    public void isThisWeek_thisMonday_true() {
+        assertEquals(true, DateTimeParser.isThisWeek(LDT_THIS_MONDAY));
+    }
+    
+    @Test
+    public void isThisWeek_lastWeek_false() {
+        assertEquals(false, DateTimeParser.isThisWeek(LDT_TODAY_LAST_WEEK));
+    }
+
+    @Test
+    public void isThisWeek_lastSunday_false() {
+        assertEquals(false, DateTimeParser.isThisWeek(LDT_LAST_SUNDAY));
+    }
+    
+    @Test
+    public void isNextWeek_nextWeek_true() {
+        assertEquals(true, DateTimeParser.isNextWeek(LDT_TODAY_NEXT_WEEK));
+    }
+    
+    @Test
+    public void isNextWeek_nextMonday_true() {
+        assertEquals(true, DateTimeParser.isNextWeek(LDT_THIS_MONDAY.plusDays(7)));
+    }
+    
+    @Test
+    public void isNextWeek_today_false() {
+        assertEquals(false, DateTimeParser.isNextWeek(LDT_TODAY));
+    }
+    
+    @Test
+    public void isNextWeek_thisSunday_false() {
+        assertEquals(false, DateTimeParser.isNextWeek(LDT_THIS_SUNDAY));
     }
 }

--- a/src/test/java/seedu/sudowudo/logic/parser/DateTimeParserTest.java
+++ b/src/test/java/seedu/sudowudo/logic/parser/DateTimeParserTest.java
@@ -27,7 +27,7 @@ public class DateTimeParserTest {
     private static final String EMPTY_STRING = "";
     
     // commonly used temporal markers
-    private static final LocalDateTime LDT_TODAY = LocalDateTime.now();
+    private static final LocalDateTime LDT_TODAY = LocalDateTime.of(LocalDate.now(), LocalTime.of(12, 0));
     private static final LocalDateTime LDT_TOMORROW = LDT_TODAY.plusDays(1);
     private static final LocalDateTime LDT_YESTERDAY = LDT_TODAY.minusDays(1);
     private static final LocalDateTime LDT_THIS_MONDAY = LDT_TODAY.with(DayOfWeek.MONDAY);
@@ -112,7 +112,16 @@ public class DateTimeParserTest {
         assertEquals(null, parser.extractEndDate());
     }
     
-    public static Date makeDate(int year, int month, int day, int hour, int minute) {
+    /*
+     * Tests for datetime prettifier methods
+     */
+    @Test
+    public void extractPrettyDateTime_today_todayReference() {
+        String expected = "Today, 12:00PM";
+        assertEquals(expected, DateTimeParser.extractPrettyDateTime(LDT_TODAY));
+    }
+    
+    private static Date makeDate(int year, int month, int day, int hour, int minute) {
         Calendar cal = Calendar.getInstance();
         cal.clear();
         cal.set(year, month-1, day, hour, minute); //month-1 because Calendar treats JANUARY as 0
@@ -154,7 +163,7 @@ public class DateTimeParserTest {
         String input = "every monday at 9am until 25 december 2016";
         parser.parse(input);
 
-        LocalDateTime recurEndDateTime = LocalDateTime.of(LocalDate.of(2016, 12, 25), LocalTime.of(9, 0));
+        LocalDateTime recurEndDateTime = LocalDateTime.of(2016, 12, 25, 9, 0);
         assertEquals(true, parser.isRecurring());
         assertEquals(recurEndDateTime, parser.getRecurEnd());
     }
@@ -261,6 +270,21 @@ public class DateTimeParserTest {
     @Test
     public void isToday_tomorrow_false() {
         assertEquals(false, DateTimeParser.isToday(LDT_TOMORROW));
+    }
+
+    @Test
+    public void isYesterday_yesterday_true() {
+        assertEquals(true, DateTimeParser.isYesterday(LDT_YESTERDAY));
+    }
+    
+    @Test
+    public void isYesterday_today_false() {
+        assertEquals(false, DateTimeParser.isYesterday(LDT_TODAY));
+    }
+
+    @Test
+    public void isYesterday_tomorrow_false() {
+        assertEquals(false, DateTimeParser.isYesterday(LDT_TOMORROW));
     }
     
     @Test

--- a/src/test/java/seedu/sudowudo/logic/parser/DateTimeParserTest.java
+++ b/src/test/java/seedu/sudowudo/logic/parser/DateTimeParserTest.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 public class DateTimeParserTest {
 
     private DateTimeParser parser = DateTimeParser.getInstance();
-    
+
     @Test
     public void extractStartDate_explicitDate_correctStartDate() {
         String input = "16 september 2016 5pm to 17 september 2016 6pm";
@@ -204,4 +204,54 @@ public class DateTimeParserTest {
         assertEquals(false, DateTimeParser.isSameDay(ldt1, ldt2));
     }
     
+    @Test
+    public void isToday_todaysDate_true() {
+        assertEquals(true, DateTimeParser.isToday(LocalDateTime.now()));
+    }
+
+    @Test
+    public void isToday_tomorrowsDate_false() {
+        assertEquals(false, DateTimeParser.isToday(LocalDateTime.now().plusDays(1)));
+    }
+    
+    @Test
+    public void isTomorrow_tomorrowsDate_true() {
+        assertEquals(true, DateTimeParser.isTomorrow(LocalDateTime.now().plusDays(1)));
+    }
+
+    @Test
+    public void isTomorrow_todaysDate_false() {
+        assertEquals(false, DateTimeParser.isTomorrow(LocalDateTime.now()));
+    }
+    
+    @Test
+    public void isWithinTwoWeeks_withinTwoWeeks_true() {
+        LocalDateTime ldt = LocalDateTime.now();
+        for(int i = 0; i < 14; i++) {
+            assertEquals(true, DateTimeParser.isWithinTwoWeeks(ldt.plusDays(i)));
+            assertEquals(true, DateTimeParser.isWithinTwoWeeks(ldt.minusDays(i)));
+        }
+    }
+    
+    @Test
+    public void isWithinTwoWeeks_outsideTwoWeeks_false() {
+        LocalDateTime ldtPlus = LocalDateTime.now().plusDays(14);
+        LocalDateTime ldtMinus = LocalDateTime.now().minusDays(14);
+        for(int i = 0; i < 14; i++) {
+            assertEquals(false, DateTimeParser.isWithinTwoWeeks(ldtPlus.plusDays(i)));
+            assertEquals(false, DateTimeParser.isWithinTwoWeeks(ldtMinus.minusDays(i)));
+        }
+    }
+    
+    @Test
+    public void isWithinThisYear_withinYear_true() {
+        LocalDateTime ldt = LocalDateTime.now();
+        assertEquals(true, DateTimeParser.isWithinThisYear(ldt));
+    }
+
+    @Test
+    public void isWithinThisYear_outsideYear_false() {
+        LocalDateTime ldt = LocalDateTime.now().plusYears(1);
+        assertEquals(false, DateTimeParser.isWithinThisYear(ldt));
+    }
 }

--- a/src/test/java/seedu/sudowudo/logic/parser/DateTimeParserTest.java
+++ b/src/test/java/seedu/sudowudo/logic/parser/DateTimeParserTest.java
@@ -19,35 +19,37 @@ import org.ocpsoft.prettytime.nlp.parse.DateGroup;
 
 //@@author A0147609X
 /**
- * beware of tests involving relative dates as the current date
- * is taken to be the current system time (whoever is building)
+ * beware of tests involving relative dates as the current date is taken to be
+ * the current system time (whoever is building)
+ * 
  * @author darren
  */
 public class DateTimeParserTest {
 
     private static final String EMPTY_STRING = "";
-    
+
     // commonly used temporal markers
     private static final LocalDateTime LDT_TODAY = LocalDateTime.of(LocalDate.now(), LocalTime.of(12, 0));
     private static final LocalDateTime LDT_TOMORROW = LDT_TODAY.plusDays(1);
     private static final LocalDateTime LDT_YESTERDAY = LDT_TODAY.minusDays(1);
     private static final LocalDateTime LDT_THIS_MONDAY = LDT_TODAY.with(DayOfWeek.MONDAY);
     private static final LocalDateTime LDT_THIS_SUNDAY = LDT_TODAY.with(DayOfWeek.SUNDAY);
-    private static final LocalDateTime LDT_LAST_SUNDAY = LDT_TODAY.with(TemporalAdjusters.previous(DayOfWeek.SUNDAY));
-    private static final LocalDateTime LDT_NEXT_MONDAY = LDT_TODAY.with(TemporalAdjusters.next(DayOfWeek.MONDAY));
+    private static final LocalDateTime LDT_LAST_SUNDAY = LDT_TODAY
+            .with(TemporalAdjusters.previous(DayOfWeek.SUNDAY));
+    private static final LocalDateTime LDT_NEXT_MONDAY = LDT_TODAY
+            .with(TemporalAdjusters.next(DayOfWeek.MONDAY));
     private static final LocalDateTime LDT_TODAY_LAST_WEEK = LDT_TODAY.minusDays(7);
     private static final LocalDateTime LDT_TODAY_NEXT_WEEK = LDT_TODAY.plusDays(7);
-    
 
     private DateTimeParser parser = DateTimeParser.getInstance();
-    
+
     @Test
     public void getDateTime_validString_stringReturned() {
         String input = "16 september 2016 5pm to 17 september 2016 6pm";
         parser.parse(input);
         assertEquals(input, parser.getDateTime());
     }
-    
+
     @Test
     public void extractStartDate_explicitDate_correctStartDate() {
         String input = "16 september 2016 5pm to 17 september 2016 6pm";
@@ -57,24 +59,24 @@ public class DateTimeParserTest {
 
         assertEquals(start, parser.extractStartDate());
     }
-    
+
     @Test
     public void extractStartDate_implicitDate_correctStartDate() {
         String input = "2213 fifth january";
         parser.parse(input);
-        
+
         LocalDateTime start = LocalDateTime.of(LocalDate.of(2016, 1, 5), LocalTime.of(22, 13));
-        
+
         assertEquals(start, parser.extractStartDate());
     }
-    
+
     @Test
     public void extractStartDate_noDateToken_null() {
         String input = "these are not the dates you are looking for";
         parser.parse(input);
         assertEquals(null, parser.extractStartDate());
     }
-    
+
     @Test
     public void extractEndDate_explicitDate_correctEndDate() {
         String input = "16 september 2016 5pm to 17 september 2016 6:30pm";
@@ -89,9 +91,9 @@ public class DateTimeParserTest {
     public void extractEndDate_implicitDate_correctEndDate() {
         String input = "1800 fifth january till the sixth october at 9:30pm";
         parser.parse(input);
-        
+
         LocalDateTime end = LocalDateTime.of(LocalDate.of(2016, 10, 6), LocalTime.of(21, 30));
-        
+
         assertEquals(end, parser.extractEndDate());
     }
 
@@ -112,7 +114,7 @@ public class DateTimeParserTest {
         assertEquals(deadline, parser.extractStartDate());
         assertEquals(null, parser.extractEndDate());
     }
-    
+
     /*
      * Tests for datetime prettifier methods
      */
@@ -125,22 +127,27 @@ public class DateTimeParserTest {
 
     @Test
     public void extractPrettyDateTime_tomorrow_tomorrowReference() {
-        String expected = DateTimeParser.TOMORROW_DATE_REF + DateTimeParser.PRETTY_COMMA_DELIMITER + "12:00PM";
+        String expected = DateTimeParser.TOMORROW_DATE_REF + DateTimeParser.PRETTY_COMMA_DELIMITER
+                + "12:00PM";
         assertEquals(expected, DateTimeParser.extractPrettyDateTime(LDT_TOMORROW));
     }
 
     @Test
     public void extractPrettyDateTime_yesterday_yesterdayReference() {
-        String expected = DateTimeParser.YESTERDAY_DATE_REF + DateTimeParser.PRETTY_COMMA_DELIMITER + "12:00PM";
+        String expected = DateTimeParser.YESTERDAY_DATE_REF + DateTimeParser.PRETTY_COMMA_DELIMITER
+                + "12:00PM";
         assertEquals(expected, DateTimeParser.extractPrettyDateTime(LDT_YESTERDAY));
     }
 
     @Test
     public void extractPrettyDateTime_lastWeek_lastWeekReference() {
-        String expected = DateTimeParser.LAST_WEEK_REF + LDT_TODAY_LAST_WEEK.format(DateTimeParser.LONG_DAYOFWEEK) + DateTimeParser.PRETTY_COMMA_DELIMITER + LDT_TODAY_LAST_WEEK.format(DateTimeParser.TWELVE_HOUR_TIME);
+        String expected = DateTimeParser.LAST_WEEK_REF
+                + LDT_TODAY_LAST_WEEK.format(DateTimeParser.LONG_DAYOFWEEK)
+                + DateTimeParser.PRETTY_COMMA_DELIMITER
+                + LDT_TODAY_LAST_WEEK.format(DateTimeParser.TWELVE_HOUR_TIME);
         assertEquals(expected, DateTimeParser.extractPrettyDateTime(LDT_TODAY_LAST_WEEK));
     }
-    
+
     @Test
     public void extractPrettyDateTime_oneYearFromNow_explicitDateFormat() {
         LocalDateTime oneYearFromNow = LDT_TODAY.plusYears(1);
@@ -148,7 +155,7 @@ public class DateTimeParserTest {
         String expected = oneYearFromNow.format(explicitFormat);
         assertEquals(expected, DateTimeParser.extractPrettyDateTime(oneYearFromNow));
     }
-    
+
     @Test
     public void extractPrettyItemCardDateTime_nullStart_prettyEndDateTimeOnly() {
         String expected = DateTimeParser.extractPrettyDateTime(LDT_TODAY);
@@ -160,20 +167,22 @@ public class DateTimeParserTest {
         String expected = DateTimeParser.extractPrettyDateTime(LDT_TODAY);
         assertEquals(expected, DateTimeParser.extractPrettyItemCardDateTime(LDT_TODAY, null));
     }
-    
+
     @Test
     public void extractPrettyItemCardDateTime_sameDayStartEnd_sameDayPeriod() {
         LocalDateTime start = LDT_TODAY;
         LocalDateTime end = LDT_TODAY.plusMinutes(60);
         assert start.isBefore(end);
-        String expected = DateTimeParser.extractPrettyDateTime(start) + DateTimeParser.PRETTY_TO_DELIMITER + DateTimeParser.extractTwelveHourTime(end);
+        String expected = DateTimeParser.extractPrettyDateTime(start) + DateTimeParser.PRETTY_TO_DELIMITER
+                + DateTimeParser.extractTwelveHourTime(end);
         assertEquals(expected, DateTimeParser.extractPrettyItemCardDateTime(start, end));
     }
-    
+
     private static Date makeDate(int year, int month, int day, int hour, int minute) {
         Calendar cal = Calendar.getInstance();
         cal.clear();
-        cal.set(year, month-1, day, hour, minute); //month-1 because Calendar treats JANUARY as 0
+        cal.set(year, month - 1, day, hour, minute); // month-1 because Calendar
+                                                     // treats JANUARY as 0
         return cal.getTime();
     }
 
@@ -188,7 +197,7 @@ public class DateTimeParserTest {
         Date date = makeDate(year, month, day, hour, minute);
 
         LocalDateTime answer = LocalDateTime.of(LocalDate.of(year, month, day), LocalTime.of(hour, minute));
-        
+
         assertEquals(answer, DateTimeParser.changeDateToLocalDateTime(date));
     }
 
@@ -203,7 +212,7 @@ public class DateTimeParserTest {
         Date date = makeDate(year, month, day, hour, minute);
 
         LocalDateTime ldt = LocalDateTime.of(LocalDate.of(year, month, day), LocalTime.of(hour, minute));
-        
+
         assertEquals(date, DateTimeParser.changeLocalDateTimeToDate(ldt));
     }
 
@@ -216,7 +225,7 @@ public class DateTimeParserTest {
         assertEquals(true, parser.isRecurring());
         assertEquals(recurEndDateTime, parser.getRecurEnd());
     }
-    
+
     @Test
     public void extractNonRecurringEventDetails() {
         String input = "on fifth of november at 5pm";
@@ -224,41 +233,42 @@ public class DateTimeParserTest {
 
         assertEquals(false, parser.isRecurring());
     }
-    
+
     private static ArrayList<LocalDateTime> generateWeeklyLDTs() {
         LocalDateTime day = LocalDateTime.of(2016, 10, 17, 12, 0); // Monday
         ArrayList<LocalDateTime> week = new ArrayList<LocalDateTime>();
 
         week.add(day);
-        
-        for(int i = 0; i < 6; i++) {
+
+        for (int i = 0; i < 6; i++) {
             day = day.plusDays(1);
             week.add(day);
         }
-        
+
         return week;
     }
-    
+
     @Test
     public void extractLongDayOfWeek_everyDayOfWeek_successfulExtract() {
         ArrayList<LocalDateTime> weekLDTs = generateWeeklyLDTs();
-        String[] daysOfWeek = {"Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"};
-        
-        for(int i = 0; i < 7; i++) {
+        String[] daysOfWeek = { "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday",
+                "Sunday" };
+
+        for (int i = 0; i < 7; i++) {
             assertEquals(daysOfWeek[i], DateTimeParser.extractLongDayOfWeek(weekLDTs.get(i)));
         }
     }
-    
+
     @Test
     public void extractShortDayOfWeek_everyDayOfWeek_successfulExtract() {
         ArrayList<LocalDateTime> weekLDTs = generateWeeklyLDTs();
-        String[] daysOfWeek = {"Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"};
-        
-        for(int i = 0; i < 7; i++) {
+        String[] daysOfWeek = { "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun" };
+
+        for (int i = 0; i < 7; i++) {
             assertEquals(daysOfWeek[i], DateTimeParser.extractShortDayOfWeek(weekLDTs.get(i)));
         }
     }
-    
+
     @Test
     public void extractTwelveHourTime_morning_successfulExtract() {
         LocalDateTime morning = LocalDateTime.of(2016, 11, 11, 11, 11);
@@ -272,7 +282,7 @@ public class DateTimeParserTest {
         String expected = "6:31PM";
         assertEquals(expected, DateTimeParser.extractTwelveHourTime(evening));
     }
-    
+
     @Test
     public void extractTwelveHourTime_midnight_successfulExtract() {
         LocalDateTime midnight = LocalDateTime.of(2016, 11, 11, 0, 0);
@@ -286,14 +296,14 @@ public class DateTimeParserTest {
         String expected = "12:00PM";
         assertEquals(expected, DateTimeParser.extractTwelveHourTime(midday));
     }
-    
+
     @Test
     public void extractTwelveHourTime_meridianSwitch_correctMeridian() {
         LocalDateTime ldt = LocalDateTime.of(2016, 11, 11, 11, 59);
         String expected = "11:59AM";
         assertEquals(expected, DateTimeParser.extractTwelveHourTime(ldt));
     }
-    
+
     @Test
     public void isSameDay_sameDay_true() {
         LocalDateTime ldt1 = LocalDateTime.of(2016, 11, 11, 11, 11);
@@ -305,7 +315,7 @@ public class DateTimeParserTest {
     public void isSameDay_differentDay_false() {
         assertEquals(false, DateTimeParser.isSameDay(LDT_TODAY, LDT_TOMORROW));
     }
-    
+
     @Test
     public void isToday_today_true() {
         assertEquals(true, DateTimeParser.isToday(LDT_TODAY));
@@ -325,7 +335,7 @@ public class DateTimeParserTest {
     public void isYesterday_yesterday_true() {
         assertEquals(true, DateTimeParser.isYesterday(LDT_YESTERDAY));
     }
-    
+
     @Test
     public void isYesterday_today_false() {
         assertEquals(false, DateTimeParser.isYesterday(LDT_TODAY));
@@ -335,7 +345,7 @@ public class DateTimeParserTest {
     public void isYesterday_tomorrow_false() {
         assertEquals(false, DateTimeParser.isYesterday(LDT_TOMORROW));
     }
-    
+
     @Test
     public void isTomorrow_tomorrow_true() {
         assertEquals(true, DateTimeParser.isTomorrow(LDT_TOMORROW));
@@ -350,45 +360,47 @@ public class DateTimeParserTest {
     public void isTomorrow_today_false() {
         assertEquals(false, DateTimeParser.isTomorrow(LDT_TODAY));
     }
-    
+
     @Test
     public void isWithinTwoWeeks_withinTwoWeeks_true() {
-        for(int i = 0; i < 14; i++) {
+        for (int i = 0; i < 14; i++) {
             assertEquals(true, DateTimeParser.isWithinTwoWeeks(LDT_TODAY.plusDays(i)));
             assertEquals(true, DateTimeParser.isWithinTwoWeeks(LDT_TODAY.minusDays(i)));
         }
     }
-    
+
     @Test
     public void isWithinTwoWeeks_outsideTwoWeeks_false() {
         LocalDateTime ldtPlus = LDT_TODAY.plusDays(14);
         LocalDateTime ldtMinus = LDT_TODAY.minusDays(14);
-        for(int i = 0; i < 14; i++) {
+        for (int i = 0; i < 14; i++) {
             assertEquals(false, DateTimeParser.isWithinTwoWeeks(ldtPlus.plusDays(i)));
             assertEquals(false, DateTimeParser.isWithinTwoWeeks(ldtMinus.minusDays(i)));
         }
     }
-    
+
     @Test
     public void isWithinThisYear_withinYear_true() {
         assertEquals(true, DateTimeParser.isWithinThisYear(LDT_TODAY));
     }
-    
+
     @Test
     public void isWithinThisYear_firstDayOfYear_true() {
-        assertEquals(true, DateTimeParser.isWithinThisYear(LDT_TODAY.with(TemporalAdjusters.firstDayOfYear())));
+        assertEquals(true,
+                DateTimeParser.isWithinThisYear(LDT_TODAY.with(TemporalAdjusters.firstDayOfYear())));
     }
-    
+
     @Test
     public void isWithinThisYear_lastDayOfYear_true() {
-        assertEquals(true, DateTimeParser.isWithinThisYear(LDT_TODAY.with(TemporalAdjusters.lastDayOfYear())));
+        assertEquals(true,
+                DateTimeParser.isWithinThisYear(LDT_TODAY.with(TemporalAdjusters.lastDayOfYear())));
     }
 
     @Test
     public void isWithinThisYear_outsideYear_false() {
         assertEquals(false, DateTimeParser.isWithinThisYear(LDT_TODAY.plusYears(1)));
     }
-    
+
     /*
      * Note: a week starts on Monday and ends on Sunday.
      */
@@ -416,7 +428,7 @@ public class DateTimeParserTest {
         // first day of this week
         assertEquals(false, DateTimeParser.isLastWeek(LDT_THIS_MONDAY));
     }
-    
+
     @Test
     public void isThisWeek_today_true() {
         assertEquals(true, DateTimeParser.isThisWeek(LDT_TODAY));
@@ -426,7 +438,7 @@ public class DateTimeParserTest {
     public void isThisWeek_thisMonday_true() {
         assertEquals(true, DateTimeParser.isThisWeek(LDT_THIS_MONDAY));
     }
-    
+
     @Test
     public void isThisWeek_lastWeek_false() {
         assertEquals(false, DateTimeParser.isThisWeek(LDT_TODAY_LAST_WEEK));
@@ -436,22 +448,22 @@ public class DateTimeParserTest {
     public void isThisWeek_lastSunday_false() {
         assertEquals(false, DateTimeParser.isThisWeek(LDT_LAST_SUNDAY));
     }
-    
+
     @Test
     public void isNextWeek_nextWeek_true() {
         assertEquals(true, DateTimeParser.isNextWeek(LDT_TODAY_NEXT_WEEK));
     }
-    
+
     @Test
     public void isNextWeek_nextMonday_true() {
         assertEquals(true, DateTimeParser.isNextWeek(LDT_NEXT_MONDAY));
     }
-    
+
     @Test
     public void isNextWeek_today_false() {
         assertEquals(false, DateTimeParser.isNextWeek(LDT_TODAY));
     }
-    
+
     @Test
     public void isNextWeek_thisSunday_false() {
         assertEquals(false, DateTimeParser.isNextWeek(LDT_THIS_SUNDAY));

--- a/src/test/java/seedu/sudowudo/logic/parser/DateTimeParserTest.java
+++ b/src/test/java/seedu/sudowudo/logic/parser/DateTimeParserTest.java
@@ -30,6 +30,7 @@ public class DateTimeParserTest {
     private static final LocalDateTime LDT_THIS_MONDAY = LDT_TODAY.with(DayOfWeek.MONDAY);
     private static final LocalDateTime LDT_THIS_SUNDAY = LDT_TODAY.with(DayOfWeek.SUNDAY);
     private static final LocalDateTime LDT_LAST_SUNDAY = LDT_TODAY.with(TemporalAdjusters.previous(DayOfWeek.SUNDAY));
+    private static final LocalDateTime LDT_NEXT_MONDAY = LDT_THIS_MONDAY.plusDays(7);
     private static final LocalDateTime LDT_TODAY_LAST_WEEK = LDT_TODAY.minusDays(7);
     private static final LocalDateTime LDT_TODAY_NEXT_WEEK = LDT_TODAY.plusDays(7);
     
@@ -322,7 +323,7 @@ public class DateTimeParserTest {
     
     @Test
     public void isNextWeek_nextMonday_true() {
-        assertEquals(true, DateTimeParser.isNextWeek(LDT_THIS_MONDAY.plusDays(7)));
+        assertEquals(true, DateTimeParser.isNextWeek(LDT_NEXT_MONDAY));
     }
     
     @Test

--- a/src/test/java/seedu/sudowudo/logic/parser/DateTimeParserTest.java
+++ b/src/test/java/seedu/sudowudo/logic/parser/DateTimeParserTest.java
@@ -33,7 +33,7 @@ public class DateTimeParserTest {
     private static final LocalDateTime LDT_THIS_MONDAY = LDT_TODAY.with(DayOfWeek.MONDAY);
     private static final LocalDateTime LDT_THIS_SUNDAY = LDT_TODAY.with(DayOfWeek.SUNDAY);
     private static final LocalDateTime LDT_LAST_SUNDAY = LDT_TODAY.with(TemporalAdjusters.previous(DayOfWeek.SUNDAY));
-    private static final LocalDateTime LDT_NEXT_MONDAY = LDT_THIS_MONDAY.plusDays(7);
+    private static final LocalDateTime LDT_NEXT_MONDAY = LDT_TODAY.with(TemporalAdjusters.next(DayOfWeek.MONDAY));
     private static final LocalDateTime LDT_TODAY_LAST_WEEK = LDT_TODAY.minusDays(7);
     private static final LocalDateTime LDT_TODAY_NEXT_WEEK = LDT_TODAY.plusDays(7);
     

--- a/src/test/java/seedu/sudowudo/logic/parser/DateTimeParserTest.java
+++ b/src/test/java/seedu/sudowudo/logic/parser/DateTimeParserTest.java
@@ -23,7 +23,7 @@ public class DateTimeParserTest {
     private DateTimeParser parser = DateTimeParser.getInstance();
     
     @Test
-    public void extractExplicitStartDateTimeTest() {
+    public void extractStartDate_explicitDate_correctStartDate() {
         String input = "16 september 2016 5pm to 17 september 2016 6pm";
         parser.parse(input);
 
@@ -33,7 +33,7 @@ public class DateTimeParserTest {
     }
     
     @Test
-    public void extractImplicitStartDateTimeTest() {
+    public void extractStartDate_implicitDate_correctStartDate() {
         String input = "2213 fifth january";
         parser.parse(input);
         
@@ -43,7 +43,7 @@ public class DateTimeParserTest {
     }
     
     @Test
-    public void extractExplicitEndDateTimeTest() {
+    public void extractEndDate_explicitDate_correctEndDate() {
         String input = "16 september 2016 5pm to 17 september 2016 6:30pm";
         parser.parse(input);
 
@@ -53,7 +53,7 @@ public class DateTimeParserTest {
     }
 
     @Test
-    public void extractImplicitEndDateTimeTest() {
+    public void extractEndDate_implicitDate_correctEndDate() {
         String input = "1800 fifth january till the sixth october at 9:30pm";
         parser.parse(input);
         
@@ -63,7 +63,7 @@ public class DateTimeParserTest {
     }
 
     @Test
-    public void extractMissingEndDateTimeTest() {
+    public void extractDates_missingEndDate_nullEndDate() {
         String input = "by 12 november 1996 at 5pm";
         parser.parse(input);
 
@@ -81,7 +81,7 @@ public class DateTimeParserTest {
     }
 
     @Test
-    public void changeDateToLocalDateTimeTest() {
+    public void changeDateToLocalDateTime_successfulCast() {
         int year = 2016;
         int month = 11;
         int day = 12;
@@ -96,7 +96,7 @@ public class DateTimeParserTest {
     }
 
     @Test
-    public void changeLocalDateTimeToDateTest() {
+    public void changeLocalDateTimeToDate_successfulCast() {
         int year = 2016;
         int month = 11;
         int day = 12;
@@ -143,7 +143,7 @@ public class DateTimeParserTest {
     }
     
     @Test
-    public void extractLongDayOfWeekTest() {
+    public void extractLongDayOfWeek_everyDayOfWeek_successfulExtract() {
         ArrayList<LocalDateTime> weekLDTs = generateWeeklyLDTs();
         String[] daysOfWeek = {"Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"};
         
@@ -153,7 +153,7 @@ public class DateTimeParserTest {
     }
     
     @Test
-    public void extractShortDayOfWeekTest() {
+    public void extractShortDayOfWeek_everyDayOfWeek_successfulExtract() {
         ArrayList<LocalDateTime> weekLDTs = generateWeeklyLDTs();
         String[] daysOfWeek = {"Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"};
         
@@ -163,42 +163,42 @@ public class DateTimeParserTest {
     }
     
     @Test
-    public void extractTwelveHourTimeTest_Morning() {
+    public void extractTwelveHourTime_morning_successfulExtract() {
         LocalDateTime morning = LocalDateTime.of(2016, 11, 11, 11, 11);
         String expected = "11:11AM";
         assertEquals(expected, DateTimeParser.extractTwelveHourTime(morning));
     }
 
     @Test
-    public void extractTwelveHourTimeTest_Evening() {
+    public void extractTwelveHourTime_evening_successfulExtract() {
         LocalDateTime evening = LocalDateTime.of(2016, 11, 11, 18, 31);
         String expected = "6:31PM";
         assertEquals(expected, DateTimeParser.extractTwelveHourTime(evening));
     }
     
     @Test
-    public void extractTwelveHourTimeTest_Midnight() {
+    public void extractTwelveHourTime_midnight_successfulExtract() {
         LocalDateTime evening = LocalDateTime.of(2016, 11, 11, 0, 0);
         String expected = "12:00AM";
         assertEquals(expected, DateTimeParser.extractTwelveHourTime(evening));
     }
 
     @Test
-    public void extractTwelveHourTimeTest_Midday() {
+    public void extractTwelveHourTime_midday_successfulExtract() {
         LocalDateTime evening = LocalDateTime.of(2016, 11, 11, 12, 0);
         String expected = "12:00PM";
         assertEquals(expected, DateTimeParser.extractTwelveHourTime(evening));
     }
     
     @Test
-    public void isSameDayTest_Positive() {
+    public void isSameDay_sameDay_true() {
         LocalDateTime ldt1 = LocalDateTime.of(2016, 11, 11, 11, 11);
         LocalDateTime ldt2 = LocalDateTime.of(2016, 11, 11, 19, 46);
         assertEquals(true, DateTimeParser.isSameDay(ldt1, ldt2));
     }
 
     @Test
-    public void isSameDayTest_Negative() {
+    public void isSameDay_differentDay_false() {
         LocalDateTime ldt1 = LocalDateTime.of(2016, 11, 11, 11, 11);
         LocalDateTime ldt2 = LocalDateTime.of(2016, 11, 15, 19, 46);
         assertEquals(false, DateTimeParser.isSameDay(ldt1, ldt2));

--- a/src/test/java/seedu/sudowudo/logic/parser/DateTimeParserTest.java
+++ b/src/test/java/seedu/sudowudo/logic/parser/DateTimeParserTest.java
@@ -65,6 +65,13 @@ public class DateTimeParserTest {
     }
     
     @Test
+    public void extractStartDate_noDateToken_null() {
+        String input = "these are not the dates you are looking for";
+        parser.parse(input);
+        assertEquals(null, parser.extractStartDate());
+    }
+    
+    @Test
     public void extractEndDate_explicitDate_correctEndDate() {
         String input = "16 september 2016 5pm to 17 september 2016 6:30pm";
         parser.parse(input);
@@ -92,6 +99,13 @@ public class DateTimeParserTest {
         LocalDateTime deadline = LocalDateTime.of(LocalDate.of(1996, 11, 12), LocalTime.of(17, 0));
 
         assertEquals(deadline, parser.extractStartDate());
+        assertEquals(null, parser.extractEndDate());
+    }
+
+    @Test
+    public void extractEndDate_noDateToken_null() {
+        String input = "these are not the dates you are looking for";
+        parser.parse(input);
         assertEquals(null, parser.extractEndDate());
     }
     

--- a/src/test/java/seedu/sudowudo/logic/parser/DateTimeParserTest.java
+++ b/src/test/java/seedu/sudowudo/logic/parser/DateTimeParserTest.java
@@ -20,10 +20,12 @@ import org.junit.Test;
  */
 public class DateTimeParserTest {
 
+    private DateTimeParser parser = DateTimeParser.getInstance();
+    
     @Test
     public void extractExplicitStartDateTimeTest() {
         String input = "16 september 2016 5pm to 17 september 2016 6pm";
-        DateTimeParser parser = new DateTimeParser(input);
+        parser.parse(input);
 
         LocalDateTime start = LocalDateTime.of(LocalDate.of(2016, 9, 16), LocalTime.of(17, 0));
 
@@ -33,7 +35,7 @@ public class DateTimeParserTest {
     @Test
     public void extractImplicitStartDateTimeTest() {
         String input = "2213 fifth january";
-        DateTimeParser parser = new DateTimeParser(input);
+        parser.parse(input);
         
         LocalDateTime start = LocalDateTime.of(LocalDate.of(2016, 1, 5), LocalTime.of(22, 13));
         
@@ -43,7 +45,7 @@ public class DateTimeParserTest {
     @Test
     public void extractExplicitEndDateTimeTest() {
         String input = "16 september 2016 5pm to 17 september 2016 6:30pm";
-        DateTimeParser parser = new DateTimeParser(input);
+        parser.parse(input);
 
         LocalDateTime end = LocalDateTime.of(LocalDate.of(2016, 9, 17), LocalTime.of(18, 30));
 
@@ -53,7 +55,7 @@ public class DateTimeParserTest {
     @Test
     public void extractImplicitEndDateTimeTest() {
         String input = "1800 fifth january till the sixth october at 9:30pm";
-        DateTimeParser parser = new DateTimeParser(input);
+        parser.parse(input);
         
         LocalDateTime end = LocalDateTime.of(LocalDate.of(2016, 10, 6), LocalTime.of(21, 30));
         
@@ -63,7 +65,7 @@ public class DateTimeParserTest {
     @Test
     public void extractMissingEndDateTimeTest() {
         String input = "by 12 november 1996 at 5pm";
-        DateTimeParser parser = new DateTimeParser(input);
+        parser.parse(input);
 
         LocalDateTime deadline = LocalDateTime.of(LocalDate.of(1996, 11, 12), LocalTime.of(17, 0));
 
@@ -111,7 +113,7 @@ public class DateTimeParserTest {
     @Test
     public void extractRecurringEventDetails() {
         String input = "every monday at 9am until 25 december 2016";
-        DateTimeParser parser = new DateTimeParser(input);
+        parser.parse(input);
 
         LocalDateTime recurEndDateTime = LocalDateTime.of(LocalDate.of(2016, 12, 25), LocalTime.of(9, 0));
         assertEquals(true, parser.isRecurring());
@@ -121,7 +123,7 @@ public class DateTimeParserTest {
     @Test
     public void extractNonRecurringEventDetails() {
         String input = "on fifth of november at 5pm";
-        DateTimeParser parser = new DateTimeParser(input);
+        parser.parse(input);
 
         assertEquals(false, parser.isRecurring());
     }

--- a/src/test/java/seedu/sudowudo/testutil/ItemBuilder.java
+++ b/src/test/java/seedu/sudowudo/testutil/ItemBuilder.java
@@ -1,7 +1,5 @@
 package seedu.sudowudo.testutil;
 
-import java.time.LocalDateTime;
-
 import seedu.sudowudo.commons.exceptions.IllegalValueException;
 import seedu.sudowudo.logic.parser.DateTimeParser;
 import seedu.sudowudo.model.item.Description;
@@ -11,38 +9,38 @@ import seedu.sudowudo.model.tag.UniqueTagList;
 public class ItemBuilder {
 
     private TestItem item;
-    
-    public ItemBuilder(){
+    private final DateTimeParser dtparser = DateTimeParser.getInstance();
+
+    public ItemBuilder() {
         this.item = new TestItem();
     }
-    //@@author A0131560U
-    public ItemBuilder withDescription(String description) throws IllegalValueException{
+
+    // @@author A0131560U
+    public ItemBuilder withDescription(String description) throws IllegalValueException {
         this.item.setDescription(new Description(description));
         return this;
     }
-    //@@author A0144750J
-    public ItemBuilder withDates(String startdate) throws IllegalValueException{
-    	DateTimeParser parser = new DateTimeParser(startdate);
-		LocalDateTime startTimeObj = parser.extractStartDate();
-		LocalDateTime endTimeObj = parser.extractStartDate();
-		this.item.setStartDate(startTimeObj);
-		this.item.setEndDate(endTimeObj);
-		return this;
+
+    // @@author A0144750J
+    public ItemBuilder withDates(String startDate) throws IllegalValueException {
+        this.dtparser.parse(startDate);
+        this.item.setStartDate(this.dtparser.extractStartDate());
+        this.item.setEndDate(this.dtparser.extractEndDate());
+        return this;
     }
-    
-    //@@author
-    public ItemBuilder withTags(String... tags) throws IllegalValueException{
-        UniqueTagList replacement = new UniqueTagList(); 
-        for (String tag : tags){
+
+    // @@author
+    public ItemBuilder withTags(String... tags) throws IllegalValueException {
+        UniqueTagList replacement = new UniqueTagList();
+        for (String tag : tags) {
             replacement.add(new Tag(tag));
         }
         this.item.setTags(replacement);
         return this;
     }
 
-    
-    public TestItem build(){
+    public TestItem build() {
         return this.item;
     }
-    
+
 }

--- a/src/test/java/seedu/sudowudo/testutil/ItemBuilder.java
+++ b/src/test/java/seedu/sudowudo/testutil/ItemBuilder.java
@@ -22,8 +22,8 @@ public class ItemBuilder {
     }
 
     // @@author A0144750J
-    public ItemBuilder withDates(String startDate) throws IllegalValueException {
-        this.dtparser.parse(startDate);
+    public ItemBuilder withDates(String datetime) throws IllegalValueException {
+        this.dtparser.parse(datetime);
         this.item.setStartDate(this.dtparser.extractStartDate());
         this.item.setEndDate(this.dtparser.extractEndDate());
         return this;

--- a/src/test/java/seedu/sudowudo/testutil/TypicalTestItems.java
+++ b/src/test/java/seedu/sudowudo/testutil/TypicalTestItems.java
@@ -20,14 +20,14 @@ public class TypicalTestItems {
             always  = new ItemBuilder().withDescription("Always brush teeth").withDates("no date info").withTags("important","priority").build();
             bags    = new ItemBuilder().withDescription("Pack bag with the thing that I always need to bring").withDates("no date info").build();
             cs2103  = new ItemBuilder().withDescription("Finish my CS2103 homework").withDates("from today to next Sunday").withTags("CS2103","homework","important").build();
-            dover   = new ItemBuilder().withDescription("Dover Road").withDates("October 5th next yeat to November 9th next year").build();
+            dover   = new ItemBuilder().withDescription("Dover Road").withDates("October 5th next year to November 9th next year").build();
             eating  = new ItemBuilder().withDescription("eat 1 child").withDates("by Friday").withTags("ohdear","feefifofum").build();
             frolick = new ItemBuilder().withDescription("frolick in the grass").withDates("from tomorrow to Sunday").build();
             grass   = new ItemBuilder().withDescription("You are allergic to grass").withDates("by next week").build();
             //@@author A0144750J
             //Manually added
             help    = new ItemBuilder().withDescription("Read help instructions").withDates("no date info").build();
-            indeed  = new ItemBuilder().withDescription("Indeed this is a test item").withDates("22/10/2016 to december 12").build();
+            indeed  = new ItemBuilder().withDescription("Indeed this is a test item").withDates("today 6pm to 12 december").build();
         } catch (IllegalValueException e) {
             e.printStackTrace();
             assert false : "not possible";


### PR DESCRIPTION
1. Method extractions for various methods inside `DateTimeParser.extractPrettyDateTime`.
2. Add more thorough unit testing for various methods in `DateTimeParser`.
3. Extract common `LocalDateTime` objects inside `DateTimeParserTest`.

Fixes #87 